### PR TITLE
Validate and default https

### DIFF
--- a/src/components/ClientPicker.jsx
+++ b/src/components/ClientPicker.jsx
@@ -50,7 +50,7 @@ class ClientPicker extends React.Component {
     const { setType, network, setUrl } = this.props;
     const type = event.target.checked ? 'private' : 'public';
     if (type === 'private' && !this.state.url_edited) {
-      setUrl(`http://localhost:${network === 'mainnet' ? 8332 : 18332}`)
+      setUrl(`https://localhost:${network === 'mainnet' ? 8332 : 18332}`)
     }
     setType(type);
   }
@@ -81,7 +81,7 @@ class ClientPicker extends React.Component {
   };
 
   validateUrl(host) {
-    const validhost = /^http(s)?:\/\/[^\s]+$/.exec(host);
+    const validhost = /^https:\/\/[^\s]+$/.exec(host);
     if (!validhost) return 'Must be a valid URL.'
     return '';
   }


### PR DESCRIPTION
Caravan must run on `https` in order to communicate with the wallets.  If you try to access `http` content you get a "mixed content" error so this updates the defaults and validation accordingly