### PR TITLE
Fix output errors being covered up

### DIFF
--- a/src/components/Spend/styles.module.scss
+++ b/src/components/Spend/styles.module.scss
@@ -11,7 +11,7 @@
 .outputsFormInput {
   font-size: 12px;
   line-height: 24px;
-  height: 38px;
+  min-height: 38px;
 }
 
 .unconfirmed {


### PR DESCRIPTION
`height` was not allowing to expand and show the errors, changed to `min-height`.