### PR TITLE
Import addresses to bitcoind

### DIFF
--- a/src/bitcoind.js
+++ b/src/bitcoind.js
@@ -2,7 +2,7 @@ import axios from 'axios';
 import BigNumber from 'bignumber.js';
 import {bitcoinsToSatoshis} from "unchained-bitcoin";
 
-async function callBitcoind(url, auth, method, params = []) {
+function callBitcoind(url, auth, method, params = []) {
   return new Promise(async (resolve, reject) => {
     axios(url, {
       method: 'post',
@@ -71,4 +71,22 @@ export async function bitcoindSendRawTransaction({url, auth, hex}) {
       throw((e.response && e.response.data.error.message) || e);
   }
 
+}
+
+export function bitcoindImportMulti({url, auth, addresses, label, rescan}) {
+  const imports = addresses.map(address => {
+    return {
+      scriptPubKey: {
+        address: address
+      },
+      label: label,
+      timestamp: 0 // TODO: better option to ensure address history is picked up?
+    }
+  });
+  if (rescan) {
+    callBitcoind(url, auth, 'importmulti', [imports, {rescan: rescan}]); // TODO: what to do on catch?
+    return new Promise(resolve => resolve({result:[]}));
+  } else {
+    return callBitcoind(url, auth, 'importmulti', [imports, {rescan: rescan}]);
+  }
 }

--- a/src/blockchain.js
+++ b/src/blockchain.js
@@ -12,7 +12,7 @@ import {
 export const BLOCK_EXPLORER = 'public';
 export const BITCOIND = 'private';
 
-function bitcoindParams(client) {
+export function bitcoindParams(client) {
   const {url, username, password} = client;
   const auth = { username, password };
   return {url, auth};

--- a/src/components/BitcoindAddressImporter.jsx
+++ b/src/components/BitcoindAddressImporter.jsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import { bitcoindImportMulti } from '../bitcoind';
+import { bitcoindParams } from '../blockchain'
+import { FormHelperText, Button, Box } from '@material-ui/core'
+
+class BitcoindAddressImporter extends React.Component {
+  static propTypes = {
+    addresses: PropTypes.array.isRequired,
+    client: PropTypes.object.isRequired,
+    rescan: PropTypes.bool.isRequired,
+  };
+
+  state = {
+    imported: false,
+    importError: "",
+  };
+
+  render() {
+    const { addresses, rescan } = this.props;
+    const { imported, importError} = this.state;
+    if (imported) {
+      if (rescan) {
+        return <FormHelperText>Initiated {this.pluralOrSingularAddress()} import, rescan of your node may take some time.</FormHelperText>
+      } else {
+        return <FormHelperText>Initiated {this.pluralOrSingularAddress()} import.</FormHelperText>
+      }
+    }
+    return (
+      <Box>
+        <FormHelperText>Addresses used with bitcoind node must be imported to your node.  If you have not already, you can import now.</FormHelperText>
+        <p>
+          Import {this.pluralOrSingularAddress()} to your node? <code>{addresses.join(", ")}</code>
+          <Box component="span" ml={2}>
+            <Button variant="contained" onClick={this.import}>Import</Button>
+          </Box>
+        </p>
+        <FormHelperText error>{importError}</FormHelperText>
+
+      </Box>
+    )
+  }
+
+  pluralOrSingularAddress() {
+    const { addresses } = this.props;
+    return `address${addresses.length > 1 ? 'es' : ''}`
+  }
+
+  import = () => {
+    const { addresses, client, rescan } = this.props;
+    const label = ""; // TODO: do we want to allow to set? or set to "caravan"?
+    bitcoindImportMulti({
+      ...bitcoindParams(client),
+      ...{addresses, label, rescan}
+    })
+    .then(response => {
+      const responseError = response.result.reduce((e, c) => {
+        return (c.error && c.error.message) || e
+      }, "")
+      this.setState({
+        importError: responseError,
+        imported: responseError === ""
+      })
+    })
+    .catch(e => {
+      this.setState({
+        importError: "Unable to import, check your settings and try again",
+        imported: false
+      });
+    });
+  }
+}
+
+function mapStateToProps(state) {
+  return {
+    client: state.client,
+  };
+}
+
+const mapDispatchToProps = {};
+
+export default connect(mapStateToProps, mapDispatchToProps)(BitcoindAddressImporter);

--- a/src/components/Spend/ScriptEntry.jsx
+++ b/src/components/Spend/ScriptEntry.jsx
@@ -25,6 +25,7 @@ import {
   FormHelperText,
 } from '@material-ui/core';
 import MultisigDetails from "../MultisigDetails";
+import BitcoindAddressImporter from "../BitcoindAddressImporter";
 
 // Actions
 import {
@@ -180,7 +181,7 @@ class ScriptEntry extends React.Component {
 
   renderDetails = () => {
     const { fetchUTXOsError } = this.state;
-    const { chosePerformSpend, choseConfirmOwnership } = this.props;
+    const { chosePerformSpend, choseConfirmOwnership, client } = this.props;
     const multisig = this.generateMultisig();
     const buttonsDisabled = (chosePerformSpend || choseConfirmOwnership);
     return (
@@ -204,6 +205,12 @@ class ScriptEntry extends React.Component {
           <FormHelperText error>{fetchUTXOsError}</FormHelperText>
 
         </Box>
+        {
+          client.type === "private" &&
+          <Box mt={2}>
+            <BitcoindAddressImporter addresses={[multisig.address]} rescan={false}/>
+          </Box>
+        }
       </div>
     );
   }


### PR DESCRIPTION
This creates an address import component for importing multiple addresses, although here only one is needed, it is preparing for the future.  The component provides a button to initiate the import and user feedback messages.

It appears after the script entry, importing here will make the list of utxos available for when you hit the "Spend from this address" button.  This seems like the logical place.

I added the call to `importmulti` which is a non-blocking command with `rescan` and provides a better user experience than `importaddress` and is better suited for future enhancements..

This is a response to #12