### PR TITLE
Fix proptypes error on confirming ownership select.

### DIFF
--- a/src/components/ScriptExplorer/ConfirmOwnership.jsx
+++ b/src/components/ScriptExplorer/ConfirmOwnership.jsx
@@ -216,6 +216,8 @@ class ConfirmOwnership extends React.Component {
     const { publicKeyImporter } = this.props;
     const { disableChangeMethod } = this.state;
     const labelId = "public-key-importer-select-label";
+    const selectLabelId = `${labelId}-select`;
+
     return (
       <Card>
         <CardHeader ref={this.titleRef} title="Confirm Ownership" />
@@ -227,7 +229,7 @@ class ConfirmOwnership extends React.Component {
               <InputLabel id={labelId}>Select Method</InputLabel>
 
               <Select
-                labelId
+                labelId={selectLabelId}
                 id="public-key-importer-select"
                 disabled={disableChangeMethod}
                 value={publicKeyImporter.method}


### PR DESCRIPTION
Fix this when confirming ownership:

```
Warning: Failed prop type: Invalid prop `labelId` of type `boolean` supplied to `ForwardRef(Select)`, expected `string`.
    in ForwardRef(Select) (created by WithStyles(ForwardRef(Select)))
    in WithStyles(ForwardRef(Select)) (at ConfirmOwnership.jsx:229)
    in div (created by ForwardRef(FormControl))
    in ForwardRef(FormControl) (created by WithStyles(ForwardRef(FormControl)))
    in WithStyles(ForwardRef(FormControl)) (at ConfirmOwnership.jsx:226)
    in form (at ConfirmOwnership.jsx:223)
    in div (created by ForwardRef(CardContent))
    in ForwardRef(CardContent) (created by WithStyles(ForwardRef(CardContent)))
    in WithStyles(ForwardRef(CardContent)) (at ConfirmOwnership.jsx:222)
    in div (created by ForwardRef(Paper))
    in ForwardRef(Paper) (created by WithStyles(ForwardRef(Paper)))
    in WithStyles(ForwardRef(Paper)) (created by ForwardRef(Card))
    in ForwardRef(Card) (created by WithStyles(ForwardRef(Card)))
    in WithStyles(ForwardRef(Card)) (at ConfirmOwnership.jsx:220)
    in ConfirmOwnership (created by ConnectFunction)
    in ConnectFunction (at ScriptExplorer/index.jsx:64)
    in div (created by Styled(MuiBox))
    in Styled(MuiBox) (at ScriptExplorer/index.jsx:63)
    in div (created by ForwardRef(Grid))
    in ForwardRef(Grid) (created by WithStyles(ForwardRef(Grid)))
    in WithStyles(ForwardRef(Grid)) (at ScriptExplorer/index.jsx:37)
    in div (created by ForwardRef(Grid))
    in ForwardRef(Grid) (created by WithStyles(ForwardRef(Grid)))
    in WithStyles(ForwardRef(Grid)) (at ScriptExplorer/index.jsx:36)
    in div (created by Styled(MuiBox))
    in Styled(MuiBox) (at ScriptExplorer/index.jsx:35)
    in Spend (created by ConnectFunction)
    in ConnectFunction (created by Context.Consumer)
    in Route (at App.jsx:26)
    in Switch (at App.jsx:23)
    in Router (created by HashRouter)
    in HashRouter (at App.jsx:22)
    in ErrorBoundary (at App.jsx:21)
    in div (created by ForwardRef(Container))
    in ForwardRef(Container) (created by WithStyles(ForwardRef(Container)))
    in WithStyles(ForwardRef(Container)) (at App.jsx:19)
    in div (at App.jsx:17)
    in App (at src/index.jsx:21)
    in Provider (at src/index.jsx:20)
```