### PR TITLE
Move wallet actions into panel at the top of wallet view

### DIFF
--- a/src/components/ImportAddressesButton.jsx
+++ b/src/components/ImportAddressesButton.jsx
@@ -24,9 +24,6 @@ const useStyles = makeStyles(() => ({
   tooltip: {
     fontSize: ".8rem",
   },
-  container: {
-    textAlign: "left",
-  },
 }));
 /**
  * @description A button for importing a set of given addresses. Includes a switch
@@ -138,7 +135,7 @@ however to know if an address has been used prior to import, a rescan needs to t
           disabled={(!enableImport && !rescan) || !addresses.length}
           onClick={importAddresses}
         >
-          Import
+          Import {pluralOrSingularAddress(true)}
         </Button>
       </Box>
       <Box component="span" ml={2}>

--- a/src/components/Slices/SliceDetails.jsx
+++ b/src/components/Slices/SliceDetails.jsx
@@ -114,10 +114,19 @@ const SliceDetails = ({ slice, client, network }) => {
         disabled: client.type !== "private",
       },
       panel: (
-        <ImportAddressesButton
-          addresses={[slice.multisig.address]}
-          client={client}
-        />
+        <div>
+          <Typography variant="h6">Import Watch-Only Address</Typography>
+          <Typography variant="caption">
+            Address must be imported to get accurate balance data. If this
+            address has previous history, a rescan may be required.
+          </Typography>
+          <Box my={3}>
+            <ImportAddressesButton
+              addresses={[slice.multisig.address]}
+              client={client}
+            />
+          </Box>
+        </div>
       ),
     },
   ];

--- a/src/components/Wallet/ExtendedPublicKeyImporter.jsx
+++ b/src/components/Wallet/ExtendedPublicKeyImporter.jsx
@@ -380,7 +380,7 @@ class ExtendedPublicKeyImporter extends React.Component {
 ExtendedPublicKeyImporter.propTypes = {
   addressType: PropTypes.string.isRequired,
   classes: PropTypes.shape({
-    xpub: PropTypes.shape({}),
+    xpub: PropTypes.string,
   }).isRequired,
   defaultBIP32Path: PropTypes.string.isRequired,
   extendedPublicKeyImporter: PropTypes.shape({

--- a/src/components/Wallet/WalletActionsPanel.jsx
+++ b/src/components/Wallet/WalletActionsPanel.jsx
@@ -1,0 +1,117 @@
+import React from "react";
+import PropTypes from "prop-types";
+import {
+  Card,
+  CardHeader,
+  CardContent,
+  Button,
+  ButtonGroup,
+  Grid,
+  makeStyles,
+  Tooltip,
+} from "@material-ui/core";
+import CircularProgress from "@material-ui/core/CircularProgress";
+import {
+  RefreshOutlined,
+  DeleteOutlined,
+  GetAppOutlined,
+} from "@material-ui/icons";
+
+import { clientPropTypes } from "../../proptypes";
+import { CARAVAN_CONFIG } from "./constants";
+
+import ImportAddressesButton from "../ImportAddressesButton";
+
+const useStyles = makeStyles(() => ({
+  card: {
+    height: "100%",
+  },
+  cardContent: {
+    textAlign: "center",
+    paddingTop: "0px",
+  },
+}));
+
+const WalletActionsPanel = ({
+  addresses,
+  client,
+  handleRefresh,
+  onClearConfig,
+  onDownloadConfig,
+  onImportAddresses,
+  refreshing,
+  walletActivated,
+}) => {
+  const classes = useStyles();
+  const handleClearClick = (e) => {
+    e.preventDefault();
+    if (sessionStorage) sessionStorage.removeItem(CARAVAN_CONFIG);
+    onClearConfig(e);
+  };
+  return (
+    <Card className={classes.card}>
+      <CardHeader title="Wallet Actions" />
+      <CardContent className={classes.cardContent}>
+        <Grid container direction="column" spacing={1}>
+          <Grid item>
+            <ButtonGroup variant="outlined">
+              <Button
+                onClick={handleRefresh}
+                disabled={!walletActivated}
+                endIcon={
+                  refreshing ? (
+                    <CircularProgress size={24} />
+                  ) : (
+                    <RefreshOutlined />
+                  )
+                }
+              >
+                Refresh
+              </Button>
+              <Button endIcon={<GetAppOutlined />} onClick={onDownloadConfig}>
+                Download Configuration
+              </Button>
+              <Tooltip title="Only clears the wallet config from browser sessions. Funds remain unaffected.">
+                <Button
+                  color="secondary"
+                  endIcon={<DeleteOutlined />}
+                  onClick={handleClearClick}
+                >
+                  Clear Wallet
+                </Button>
+              </Tooltip>
+            </ButtonGroup>
+          </Grid>
+          {client.type === "private" && (
+            <Grid item>
+              <ImportAddressesButton
+                addresses={addresses}
+                client={client}
+                importCallback={onImportAddresses}
+              />
+            </Grid>
+          )}
+        </Grid>
+      </CardContent>
+    </Card>
+  );
+};
+
+WalletActionsPanel.propTypes = {
+  addresses: PropTypes.arrayOf(PropTypes.string),
+  onImportAddresses: PropTypes.func.isRequired,
+  walletActivated: PropTypes.bool,
+  handleRefresh: PropTypes.func.isRequired,
+  onClearConfig: PropTypes.func.isRequired,
+  onDownloadConfig: PropTypes.func.isRequired,
+  refreshing: PropTypes.bool,
+  client: PropTypes.shape(clientPropTypes).isRequired,
+};
+
+WalletActionsPanel.defaultProps = {
+  walletActivated: false,
+  refreshing: false,
+  addresses: [],
+};
+
+export default WalletActionsPanel;

--- a/src/components/Wallet/WalletActionsPanel.jsx
+++ b/src/components/Wallet/WalletActionsPanel.jsx
@@ -13,7 +13,7 @@ import {
 import CircularProgress from "@material-ui/core/CircularProgress";
 import {
   RefreshOutlined,
-  DeleteOutlined,
+  ExitToAppOutlined,
   GetAppOutlined,
 } from "@material-ui/icons";
 
@@ -25,10 +25,14 @@ import ImportAddressesButton from "../ImportAddressesButton";
 const useStyles = makeStyles(() => ({
   card: {
     height: "100%",
+    flexDirection: "column",
+    display: "flex",
   },
   cardContent: {
     textAlign: "center",
     paddingTop: "0px",
+    display: "flex",
+    flex: 1,
   },
 }));
 
@@ -52,29 +56,35 @@ const WalletActionsPanel = ({
     <Card className={classes.card}>
       <CardHeader title="Wallet Actions" />
       <CardContent className={classes.cardContent}>
-        <Grid container direction="column" spacing={1}>
-          <Grid item>
+        <Grid container spacing={1} alignItems="center" justify="center">
+          <Grid item xs={12}>
             <ButtonGroup variant="outlined">
-              <Button
-                onClick={handleRefresh}
-                disabled={!walletActivated}
-                endIcon={
-                  refreshing ? (
-                    <CircularProgress size={24} />
-                  ) : (
-                    <RefreshOutlined />
-                  )
-                }
-              >
-                Refresh
-              </Button>
-              <Button endIcon={<GetAppOutlined />} onClick={onDownloadConfig}>
-                Download Configuration
-              </Button>
+              <Tooltip title="Force a refresh for latest wallet state and balance.">
+                <Button
+                  onClick={handleRefresh}
+                  disabled={!walletActivated}
+                  startIcon={
+                    refreshing ? (
+                      <CircularProgress size={24} />
+                    ) : (
+                      <RefreshOutlined />
+                    )
+                  }
+                >
+                  Refresh
+                </Button>
+              </Tooltip>
+              <Tooltip title="Download wallet configuration to local machine for backup. No security is lost with this, but access to this file provides anyone who has it information about balances.">
+                <Button
+                  startIcon={<GetAppOutlined />}
+                  onClick={onDownloadConfig}
+                >
+                  Download Configuration
+                </Button>
+              </Tooltip>
               <Tooltip title="Only clears the wallet config from browser sessions. Funds remain unaffected.">
                 <Button
-                  color="secondary"
-                  endIcon={<DeleteOutlined />}
+                  startIcon={<ExitToAppOutlined />}
                   onClick={handleClearClick}
                 >
                   Clear Wallet

--- a/src/components/Wallet/WalletInfoCard.jsx
+++ b/src/components/Wallet/WalletInfoCard.jsx
@@ -14,6 +14,9 @@ import BitcoinIcon from "../BitcoinIcon";
 import EditableName from "../EditableName";
 
 const useStyles = makeStyles((theme) => ({
+  root: {
+    height: "100%",
+  },
   title: {
     fontSize: "2rem",
     color: "#212529",
@@ -39,7 +42,7 @@ const WalletInfoCard = ({
 }) => {
   const classes = useStyles();
   return (
-    <Card>
+    <Card className={classes.root}>
       <CardContent>
         <Grid container direction="row" alignItems="center">
           {editable ? (

--- a/src/proptypes/slice.js
+++ b/src/proptypes/slice.js
@@ -16,7 +16,7 @@ const slicePropTypes = {
   spend: PropTypes.bool.isRequired,
   fetchUtxos: PropTypes.bool,
   fetchUTXOsError: PropTypes.string.isRequired,
-  addressUsed: PropTypes.bool.isRequired,
+  addressUsed: PropTypes.bool,
   addressKnown: PropTypes.bool.isRequired,
   lastUsed: PropTypes.string,
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## PR Type

<!---
  What types of change(s) does your code introduce?
  Put an `x` in all the boxes that apply:
-->

* [x] Bug fix
* [ ] Feature
* [ ] Code style update (whitespace, formatting, missing semicolons, etc.)
* [x] Refactor (i.e., no functional changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation changes
* [X] Design/UI change

## Description
Move wallet actions to their own panel at top of wallet view. Required some refactoring of code where some actions and state were being handled in child components. Moved these up into the main wallet container so this state could be shared. 

Added a tooltip for the clear wallet button to make clear that this doesn't clear any funds from the wallet but only clears state from the browser session.

this is what it looks like for private clients (includes the import button)
![Screen Shot 2020-04-22 at 11 12 57 PM](https://user-images.githubusercontent.com/4344978/80058615-5d902780-84ef-11ea-88a9-754cd6ca4941.png)

And this is what it is for public clients (without important button)
![Screen Shot 2020-04-22 at 11 13 26 PM](https://user-images.githubusercontent.com/4344978/80058617-5e28be00-84ef-11ea-8a51-7e0afdf72dc5.png)

