### PR TITLE
Fix typo when deriving a public key from an xpub.

### DIFF
--- a/src/components/CreateAddress/ExtendedPublicKeyPublicKeyImporter.jsx
+++ b/src/components/CreateAddress/ExtendedPublicKeyPublicKeyImporter.jsx
@@ -63,7 +63,7 @@ class ExtendedPublicKeyPublicKeyImporter extends React.Component {
             </FormHelperText>
           </Box>
         )}
-        )
+
         <Box mt={2}>
           <Grid container>
             <Grid item md={10}>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## PR Type

<!---
  What types of change(s) does your code introduce?
  Put an `x` in all the boxes that apply:
-->

* [x] Bug fix
* [ ] Feature
* [ ] Code style update (whitespace, formatting, missing semicolons, etc.)
* [ ] Refactor (i.e., no functional changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation changes
* [ ] Other (please describe below):

## Description
Remove extraneous '(' from the form to derive a pub key from an xpub
when creating an address.

![bugbug](https://user-images.githubusercontent.com/4116405/80722740-b6525800-8acd-11ea-894d-d8012f433dcd.png)


<!---
  Please describe your change(s) in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

## Does this PR introduce a breaking change?

<!--
  If this PR contains a breaking change,
  please also describe the impact and migration path for existing applications
-->

* [ ] Yes
* [x] No

## Does this PR fixes open issues?

<!-- If this PR contain fixes to open issues please link them here -->

* [ ] Yes
* [x] No
