### PR TITLE
Fix fee calculation display with scientific notation

### DIFF
--- a/src/components/ScriptExplorer/OutputsForm.jsx
+++ b/src/components/ScriptExplorer/OutputsForm.jsx
@@ -159,7 +159,11 @@ class OutputsForm extends React.Component {
 
   handleFeeRateChange = (event) => {
     const { setFeeRate, inputs } = this.props;
-    if (inputs.length) setFeeRate(event.target.value);
+    let rate = event.target.value;
+    // eslint-disable-next-line use-isnan
+    if (rate === "" || parseFloat(rate, 10) === NaN || parseFloat(rate, 10) < 1)
+      rate = "0";
+    if (inputs.length) setFeeRate(rate);
   };
 
   handleFeeChange = (event) => {
@@ -304,7 +308,7 @@ class OutputsForm extends React.Component {
                   fullWidth
                   value={feeRate}
                   type="number"
-                  minimum={1}
+                  minimum={0}
                   step={1}
                   name="fee_rate"
                   disabled={finalizedOutputs}

--- a/src/components/ScriptExplorer/OutputsForm.jsx
+++ b/src/components/ScriptExplorer/OutputsForm.jsx
@@ -303,6 +303,9 @@ class OutputsForm extends React.Component {
                 <TextField
                   fullWidth
                   value={feeRate}
+                  type="number"
+                  minimum={1}
+                  step={1}
                   name="fee_rate"
                   disabled={finalizedOutputs}
                   onChange={this.handleFeeRateChange}

--- a/src/reducers/transactionReducer.js
+++ b/src/reducers/transactionReducer.js
@@ -435,10 +435,14 @@ function handleChangeAddressAndDust(
     });
   }
   const newOutputTotalSats = calcOutputTotalSats(newState);
+  const newFeeBTC = new BigNumber(
+    setFeeForRate(newState, newState.feeRate, newState.outputs.length)
+  );
   newState = updateState(newState, {
-    fee: setFeeForRate(newState, newState.feeRate, newState.outputs.length),
+    fee: newFeeBTC.toFixed(8).toString(),
   });
-  const newFeeSats = bitcoinsToSatoshis(new BigNumber(newState.fee));
+
+  const newFeeSats = bitcoinsToSatoshis(newFeeBTC);
 
   let balanceError = "";
   if (

--- a/src/reducers/transactionReducer.js
+++ b/src/reducers/transactionReducer.js
@@ -455,11 +455,9 @@ function handleChangeAddressAndDust(
     newState.outputs.length
   );
 
-  newState = updateState(newState, {
-    fee,
-  });
+  newState = updateState(newState, { fee });
 
-  const newFeeSats = bitcoinsToSatoshis(new BigNumber(newState.fee));
+  const newFeeSats = bitcoinsToSatoshis(new BigNumber(fee));
 
   let balanceError = "";
   if (

--- a/src/reducers/transactionReducer.js
+++ b/src/reducers/transactionReducer.js
@@ -119,17 +119,15 @@ function calcOutputTotalSats(state) {
 }
 
 function setFeeForRate(state, feeRateString, nout) {
-  return new BigNumber(
-    satoshisToBitcoins(
-      estimateMultisigTransactionFee({
-        addressType: state.addressType,
-        numInputs: state.inputs.length,
-        numOutputs: nout,
-        m: state.requiredSigners,
-        n: state.totalSigners,
-        feesPerByteInSatoshis: feeRateString,
-      })
-    )
+  return satoshisToBitcoins(
+    estimateMultisigTransactionFee({
+      addressType: state.addressType,
+      numInputs: state.inputs.length,
+      numOutputs: nout,
+      m: state.requiredSigners,
+      n: state.totalSigners,
+      feesPerByteInSatoshis: feeRateString,
+    })
   )
     .toFixed(8)
     .toString();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## PR Type

<!---
  What types of change(s) does your code introduce?
  Put an `x` in all the boxes that apply:
-->

* [x] Bug fix
* [ ] Feature
* [ ] Code style update (whitespace, formatting, missing semicolons, etc.)
* [ ] Refactor (i.e., no functional changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation changes
* [ ] Other (please describe below):

## Description
There were certain edge cases where the estimated fee display would show in scientific notation. While I couldn't find a way to replicate the circumstances where I first saw this, and therefore don't know for sure if this solves the original issue, I could get the same result by having a fee rate at a fraction of a satoshi (i.e. 0 < n < 1). The function that needed to be fixed was used in several places and so I believe this should catch the underlying issue (which seemed to need a BigNumber that was then converted to a fixed float string). 

In addition, I made the fee rate explicitly a number type html input to avoid the situations where we would get NaN and set a step value as an integer to make it easier to avoid decimal points. There is also a validation check now in the `transactionReducer` that will make sure the total fee is greater than the minimum possible (fee where rate is 1 sat/byte and there are no inputs or outputs) which will further prevent txs with a fee rate less than 1. 

![fee_rate](https://user-images.githubusercontent.com/4344978/80780401-6fe41400-8b34-11ea-9e0e-e47817b7ca2e.gif)

<!---
  Please describe your change(s) in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

## Does this PR introduce a breaking change?

<!--
  If this PR contains a breaking change,
  please also describe the impact and migration path for existing applications
-->

* [ ] Yes
* [x] No

## Does this PR fixes open issues?

<!-- If this PR contain fixes to open issues please link them here -->

* [x] Yes
* [ ] No
