### PR TITLE
Fix private client connection bugs

### DIFF
--- a/src/components/ClientPicker/index.jsx
+++ b/src/components/ClientPicker/index.jsx
@@ -94,6 +94,7 @@ class ClientPicker extends React.Component {
 
   testConnection = async () => {
     const { network, client } = this.props;
+    console.log("testing connection...");
     this.setState({ connectError: "", connectSuccess: false });
     try {
       await fetchFeeEstimate(network, client);

--- a/src/components/CreateAddress/index.jsx
+++ b/src/components/CreateAddress/index.jsx
@@ -12,11 +12,12 @@ import PublicKeyImporter from "./PublicKeyImporter";
 import ClientPicker from "../ClientPicker";
 import ImportAddressesButton from "../ImportAddressesButton";
 
+import { clientPropTypes } from "../../proptypes";
 import "../styles.css";
 
 class CreateAddress extends React.Component {
   render = () => {
-    const { address } = this.props;
+    const { address, client } = this.props;
     return (
       <Box mt={2}>
         <Grid container spacing={3}>
@@ -39,32 +40,28 @@ class CreateAddress extends React.Component {
             <Box mt={2}>
               <NetworkPicker />
             </Box>
-            {address !== "" && this.renderClientPicker()}
+            <Box mt={2}>
+              <ClientPicker
+                publicNotes={
+                  <span>
+                    If you plan to use this address with your own bitcoind node
+                    you can import the address created here by switching for
+                    &quot;Public&quot; to &quot;Private&quot;. Otherwise no
+                    action is needed here.
+                  </span>
+                }
+                privateNotes={
+                  <div>
+                    <ImportAddressesButton
+                      addresses={[address]}
+                      client={client}
+                    />
+                  </div>
+                }
+              />
+            </Box>
           </Grid>
         </Grid>
-      </Box>
-    );
-  };
-
-  renderClientPicker = () => {
-    const { address } = this.props;
-    return (
-      <Box mt={2}>
-        <ClientPicker
-          publicNotes={
-            <span>
-              If you plan to use this address with your own bitcoind node you
-              can import the address created here by switching for
-              &quot;Public&quot; to &quot;Private&quot;. Otherwise no action is
-              needed here.
-            </span>
-          }
-          privateNotes={
-            <div>
-              <ImportAddressesButton addresses={[address]} />
-            </div>
-          }
-        />
       </Box>
     );
   };
@@ -91,12 +88,14 @@ function mapStateToProps(state) {
   return {
     ...{ totalSigners: state.settings.totalSigners },
     ...state.address,
+    client: state.client,
   };
 }
 
 CreateAddress.propTypes = {
   address: PropTypes.string,
   totalSigners: PropTypes.number.isRequired,
+  client: PropTypes.shape(clientPropTypes).isRequired,
 };
 
 CreateAddress.defaultProps = {

--- a/src/components/ImportAddressesButton.jsx
+++ b/src/components/ImportAddressesButton.jsx
@@ -48,6 +48,7 @@ function ImportAddressesButton({ addresses = [], client, importCallback }) {
       // reset in case we can't import
       setEnableImport(false);
       const address = addresses[addresses.length - 1]; // TODO: loop, or maybe just check one
+      if (!address) return;
       try {
         const status = await bitcoindGetAddressStatus({
           // TODO: use this to warn if spent
@@ -88,7 +89,8 @@ function ImportAddressesButton({ addresses = [], client, importCallback }) {
     ) {
       checkAddress();
     }
-  }, [addresses, client, enableImport]);
+    // eslint-disable-next-line
+  }, [addresses, client]);
 
   // return "addresses" or "address"
   const pluralOrSingularAddress = (capitalize = false) =>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## PR Type

<!---
  What types of change(s) does your code introduce?
  Put an `x` in all the boxes that apply:
-->

* [x] Bug fix
* [ ] Feature
* [ ] Code style update (whitespace, formatting, missing semicolons, etc.)
* [ ] Refactor (i.e., no functional changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation changes
* [ ] Other (please describe below):

## Description
* Selecting private node on script explorer page hits your node with many requests per second 
* Switching client from public to private causes TypeError after importing public keys

The first was fixed by not running the check whenever the `enableImport` state was changed this his happened in the effect too and so created an infinite loop until a connection succeeded. 

The second was fixed by always showing the client selector and making sure it is passed the correct props. 

<!---
  Please describe your change(s) in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

## Does this PR introduce a breaking change?

<!--
  If this PR contains a breaking change,
  please also describe the impact and migration path for existing applications
-->

* [ ] Yes
* [x] No

## Does this PR fixes open issues?

<!-- If this PR contain fixes to open issues please link them here -->

* [ ] Yes
* [x] No
