### PR TITLE
better state management in WalletSpend components

### DIFF
--- a/src/components/Wallet/WalletSign.jsx
+++ b/src/components/Wallet/WalletSign.jsx
@@ -30,6 +30,12 @@ class WalletSign extends React.Component {
     };
   }
 
+  componentWillUnmount() {
+    const { resetTransaction } = this.props;
+    const { spent } = this.state;
+    if (spent) resetTransaction();
+  }
+
   render = () => {
     const { spent } = this.state;
     return (
@@ -62,13 +68,15 @@ class WalletSign extends React.Component {
         )}
 
         {(this.transactionFinalized() || spent) && (
-          <Button
-            variant="contained"
-            color="primary"
-            onClick={this.handleReturn}
-          >
-            Return
-          </Button>
+          <Box mt={2}>
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={this.handleReturn}
+            >
+              Return
+            </Button>
+          </Box>
         )}
       </Box>
     );

--- a/src/components/Wallet/WalletSpend.jsx
+++ b/src/components/Wallet/WalletSpend.jsx
@@ -44,24 +44,16 @@ class WalletSpend extends React.Component {
 
   feeAmount = new BigNumber(0);
 
-  // FIXME
-  // eslint-disable-next-line camelcase
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    if (nextProps.autoSpend) {
+  componentDidUpdate() {
+    const { autoSpend, finalizedOutputs } = this.props;
+    if (autoSpend && !finalizedOutputs) {
       setTimeout(this.selectCoins, 0);
     }
   }
 
   componentDidMount = () => {
-    const {
-      changeNode,
-      setChangeAddress,
-      finalizeOutputs,
-      finalizedOutputs,
-      autoSpend,
-    } = this.props;
+    const { changeNode, setChangeAddress, autoSpend } = this.props;
     if (autoSpend) setChangeAddress(changeNode.multisig.address);
-    if (finalizedOutputs) finalizeOutputs(false);
   };
 
   previewDisabled = () => {
@@ -126,13 +118,6 @@ class WalletSpend extends React.Component {
 
   handleSpendMode = (event) => {
     const { updateAutoSpend } = this.props;
-    if (event.target.checked) {
-      // select inputs for transaction
-      // select change address???,
-      // how to identify???
-      // calculate change???
-    }
-
     updateAutoSpend(!event.target.checked);
   };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## PR Type

<!---
  What types of change(s) does your code introduce?
  Put an `x` in all the boxes that apply:
-->

* [x] Bug fix
* [ ] Feature
* [ ] Code style update (whitespace, formatting, missing semicolons, etc.)
* [ ] Refactor (i.e., no functional changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation changes
* [ ] Other (please describe below):

## Description
This change fixes some weird/unexpected behavior in the wallet view when switching between tabs at different stages of a wallet spend.

The issue seemed to come from how the react component lifecycle methods were being used to call the `selectCoins` method causing some asynchronous calls to the redux dispatcher. This ended up clearing some parts of the store, causing some re-renders in components before the state was properly updated. 

This change is more selective about when to reset the state, in particular making sure that coin selection happens only if the props change, the view in autoSpend mode, AND the outputs are not finalized. 

Also if the wallet spend view is unmounted (i.e. when the tab changes) and the tx has been spent, then the `spend.transaction` part of the state is reset. This should avoid a bug where a transaction could be broadcast and then attempted to be re-broadcast after switching views. 

<!---
  Please describe your change(s) in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

## Does this PR introduce a breaking change?

<!--
  If this PR contains a breaking change,
  please also describe the impact and migration path for existing applications
-->

* [ ] Yes
* [x] No
