### PR TITLE
feat (wallet): synchronous auto spend and coin selection + max spend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8956,9 +8956,9 @@
       "integrity": "sha1-ksnBN0w1CF912zWexWzCV8u5P6Q="
     },
     "http-proxy": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.0.tgz",
-      "integrity": "sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
       "requires": {
         "eventemitter3": "^4.0.0",
         "follow-redirects": "^1.0.0",

--- a/src/actions/transactionActions.jsx
+++ b/src/actions/transactionActions.jsx
@@ -1,3 +1,12 @@
+import BigNumber from "bignumber.js";
+import {
+  estimateMultisigTransactionFee,
+  satoshisToBitcoins,
+} from "unchained-bitcoin";
+
+import { getSpendableSlices, getConfirmedBalance } from "../selectors/wallet";
+import { DUST_IN_BTC } from "../utils/constants";
+
 export const CHOOSE_PERFORM_SPEND = "CHOOSE_PERFORM_SPEND";
 
 export const SET_REQUIRED_SIGNERS = "SET_REQUIRED_SIGNERS";
@@ -201,5 +210,62 @@ export function setSpendStep(value) {
   return {
     type: SET_SPEND_STEP,
     value,
+  };
+}
+
+/**
+ * @description Given an output index and the current state of the transaction,
+ * calculate an estimated fee for a tx with all spendable utxos as inputs,
+ * and then use that to determine value of an output that spends all spendable funds
+ * minus fee. Dispatches an action to add that value to the given output.
+ * @param {Number} outputIndex - 1-indexed location of the output
+ * to add all remaining spendable funds to
+ */
+export function setMaxSpendOnOutput(outputIndex) {
+  return (dispatch, getState) => {
+    const spendableSlices = getSpendableSlices(getState());
+    const confirmedBalance = getConfirmedBalance(getState());
+    const {
+      settings: { addressType, requiredSigners, totalSigners },
+      spend: {
+        transaction: { outputs, feeRate },
+      },
+    } = getState();
+    const numInputs = spendableSlices.reduce(
+      (count, slice) => count + slice.utxos.length,
+      0
+    );
+    const estimatedFee = estimateMultisigTransactionFee({
+      addressType,
+      numInputs,
+      numOutputs: outputs.length,
+      m: requiredSigners,
+      n: totalSigners,
+      feesPerByteInSatoshis: feeRate,
+    });
+
+    const totalOutputValue = outputs.reduce(
+      (total, output) =>
+        total.plus(output.amount.length ? output.amountSats : 0),
+      new BigNumber(0)
+    );
+
+    const spendAllAmount = satoshisToBitcoins(
+      new BigNumber(confirmedBalance)
+        .minus(outputs.length > 1 ? totalOutputValue : 0)
+        .minus(estimatedFee)
+    );
+
+    if (
+      (spendAllAmount.isLessThanOrEqualTo(satoshisToBitcoins(estimatedFee)) &&
+        outputs.length > 1) ||
+      spendAllAmount.isLessThan(DUST_IN_BTC)
+    )
+      return dispatch(
+        setBalanceError(
+          "Not enough available funds for max spend. Clear other outputs or wait for incoming deposits to confirm."
+        )
+      );
+    return dispatch(setOutputAmount(outputIndex, spendAllAmount.toFixed()));
   };
 }

--- a/src/components/AppContainer.jsx
+++ b/src/components/AppContainer.jsx
@@ -14,8 +14,7 @@ class AppContainer extends Component {
     // and reset the redux store which is needed
     // to avoid conflicts in the state between views/pages
     this.unlisten = this.history.listen(() => {
-      // add delay so the form doesn't seem to flash before view changes
-      setTimeout(resetApp, 250);
+      resetApp();
     });
   }
 

--- a/src/components/Copyable.jsx
+++ b/src/components/Copyable.jsx
@@ -72,7 +72,10 @@ const Copyable = ({
         options={{ format: "text/plain" }}
       >
         <span
-          style={{ fontStyle: copied ? "italic" : "inherit" }}
+          style={{
+            fontStyle: copied ? "italic" : "inherit",
+            overflowWrap: "break-word",
+          }}
           className={`copyable ${classes.copyText}`}
         >
           {children}

--- a/src/components/ScriptExplorer/OutputEntry.jsx
+++ b/src/components/ScriptExplorer/OutputEntry.jsx
@@ -18,6 +18,7 @@ import {
   IconButton,
   InputAdornment,
   FormHelperText,
+  Typography,
 } from "@material-ui/core";
 import AccountBalanceWalletOutlinedIcon from "@material-ui/icons/AccountBalanceWallet";
 import { Delete, AddCircle, RemoveCircle } from "@material-ui/icons";
@@ -26,6 +27,7 @@ import {
   setOutputAmount,
   deleteOutput,
   setChangeOutputIndex,
+  setMaxSpendOnOutput,
 } from "../../actions/transactionActions";
 
 // Assets
@@ -202,6 +204,12 @@ class OutputEntry extends React.Component {
     remove(number);
   };
 
+  handleMaxSpend = (e) => {
+    e.preventDefault();
+    const { number, setMaxSpend } = this.props;
+    setMaxSpend(number);
+  };
+
   render() {
     const {
       outputs,
@@ -213,6 +221,7 @@ class OutputEntry extends React.Component {
       changeOutputIndex,
       autoSpend,
       isWallet,
+      number,
     } = this.props;
 
     const gridSpacing = isWallet ? 10 : 1;
@@ -246,6 +255,21 @@ class OutputEntry extends React.Component {
             error={this.hasAmountError()}
             helperText={amountError}
             InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  {isWallet &&
+                    autoSpend &&
+                    number === outputs.length &&
+                    number !== changeOutputIndex && (
+                      <Typography
+                        onClick={this.handleMaxSpend}
+                        className={styles.maxSpend}
+                      >
+                        MAX
+                      </Typography>
+                    )}
+                </InputAdornment>
+              ),
               endAdornment: (
                 <InputAdornment position="end">
                   <FormHelperText>BTC</FormHelperText>
@@ -254,7 +278,6 @@ class OutputEntry extends React.Component {
             }}
           />
         </Grid>
-
         {this.displayBalanceAction() && (
           <Grid item xs={1}>
             <Tooltip
@@ -319,6 +342,7 @@ OutputEntry.propTypes = {
   remove: PropTypes.func.isRequired,
   setAddress: PropTypes.func.isRequired,
   setAmount: PropTypes.func.isRequired,
+  setMaxSpend: PropTypes.func.isRequired,
   setChangeOutput: PropTypes.func.isRequired,
 };
 
@@ -339,6 +363,7 @@ const mapDispatchToProps = {
   setAmount: setOutputAmount,
   remove: deleteOutput,
   setChangeOutput: setChangeOutputIndex,
+  setMaxSpend: setMaxSpendOnOutput,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(OutputEntry);

--- a/src/components/ScriptExplorer/OutputEntry.jsx
+++ b/src/components/ScriptExplorer/OutputEntry.jsx
@@ -264,6 +264,7 @@ class OutputEntry extends React.Component {
                       <Typography
                         onClick={this.handleMaxSpend}
                         className={styles.maxSpend}
+                        style={{ fontSize: ".7rem" }}
                       >
                         MAX
                       </Typography>

--- a/src/components/ScriptExplorer/OutputsForm.jsx
+++ b/src/components/ScriptExplorer/OutputsForm.jsx
@@ -105,8 +105,7 @@ class OutputsForm extends React.Component {
   };
 
   outputsAndFeeTotal = () => {
-    const { outputs, fee, inputs, updatesComplete } = this.props;
-    if (!inputs.length) return "";
+    const { outputs, fee, updatesComplete } = this.props;
 
     const total = outputs
       .map((output) => new BigNumber(output.amount || 0))
@@ -339,31 +338,34 @@ class OutputsForm extends React.Component {
             <Grid item xs={4}>
               <Box mt={feeMt}>&nbsp;</Box>
             </Grid>
-
-            <Grid item xs={3}>
-              <Box mt={feeMt}>
-                <Typography
-                  variant="caption"
-                  className={styles.outputsFormLabel}
-                >
-                  Estimated Fees
-                </Typography>
-                <TextField
-                  fullWidth
-                  name="fee_total"
-                  disabled={finalizedOutputs}
-                  value={feeDisplay}
-                  onChange={this.handleFeeChange}
-                  error={this.hasFeeError()}
-                  helperText={feeError}
-                  InputProps={OutputsForm.unitLabel("BTC", {
-                    readOnly: true,
-                    disableUnderline: true,
-                    style: { color: "gray" },
-                  })}
-                />
-              </Box>
-            </Grid>
+            {!isWallet || (isWallet && !autoSpend) ? (
+              <Grid item xs={3}>
+                <Box mt={feeMt}>
+                  <Typography
+                    variant="caption"
+                    className={styles.outputsFormLabel}
+                  >
+                    Estimated Fees
+                  </Typography>
+                  <TextField
+                    fullWidth
+                    name="fee_total"
+                    disabled={finalizedOutputs}
+                    value={feeDisplay}
+                    onChange={this.handleFeeChange}
+                    error={this.hasFeeError()}
+                    helperText={feeError}
+                    InputProps={OutputsForm.unitLabel("BTC", {
+                      readOnly: true,
+                      disableUnderline: true,
+                      style: { color: "gray" },
+                    })}
+                  />
+                </Box>
+              </Grid>
+            ) : (
+              ""
+            )}
 
             <Grid item xs={2} />
           </Grid>
@@ -376,7 +378,6 @@ class OutputsForm extends React.Component {
                     ? "Totals"
                     : "Outputs & Fee Total"}
                 </Typography>
-                <small>(including change)</small>
               </Box>
             </Grid>
             <Grid item xs={3}>

--- a/src/components/ScriptExplorer/OutputsForm.jsx
+++ b/src/components/ScriptExplorer/OutputsForm.jsx
@@ -368,9 +368,6 @@ class OutputsForm extends React.Component {
                     ? "Totals"
                     : "Output Total"}
                 </Typography>
-                {isWallet && autoSpend && (
-                  <small>(change and fees calculated in next step)</small>
-                )}
               </Box>
             </Grid>
             <Grid item xs={3}>

--- a/src/components/ScriptExplorer/styles.module.scss
+++ b/src/components/ScriptExplorer/styles.module.scss
@@ -25,3 +25,13 @@
 .outputsFormLabel {
   color: rgba(0, 0, 0, 0.54);
 }
+
+.maxSpend {
+  color: grey;
+  font-size: .7rem!important;
+  text-decoration: underline;
+  &:hover {
+    cursor: pointer;
+    text-decoration: none;
+  }
+}

--- a/src/components/ScriptExplorer/styles.module.scss
+++ b/src/components/ScriptExplorer/styles.module.scss
@@ -28,7 +28,6 @@
 
 .maxSpend {
   color: grey;
-  font-size: .7rem!important;
   text-decoration: underline;
   &:hover {
     cursor: pointer;

--- a/src/components/Wallet/TransactionPreview.jsx
+++ b/src/components/Wallet/TransactionPreview.jsx
@@ -25,7 +25,7 @@ class TransactionPreview extends React.Component {
       fee,
       inputsTotalSats,
       editTransaction,
-      signTransaction,
+      handleSignTransaction,
     } = this.props;
 
     return (
@@ -69,7 +69,7 @@ class TransactionPreview extends React.Component {
               <Button
                 variant="contained"
                 color="primary"
-                onClick={signTransaction}
+                onClick={handleSignTransaction}
               >
                 Sign Transaction
               </Button>
@@ -208,15 +208,7 @@ TransactionPreview.propTypes = {
   inputs: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   inputsTotalSats: PropTypes.shape({}).isRequired,
   outputs: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
-  signTransaction: PropTypes.func.isRequired,
+  handleSignTransaction: PropTypes.func.isRequired,
 };
 
-function mapStateToProps(state) {
-  return {
-    ...state.spend.transaction,
-  };
-}
-
-const mapDispatchToProps = {};
-
-export default connect(mapStateToProps, mapDispatchToProps)(TransactionPreview);
+export default TransactionPreview;

--- a/src/components/Wallet/TransactionPreview.jsx
+++ b/src/components/Wallet/TransactionPreview.jsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { connect } from "react-redux";
 import PropTypes from "prop-types";
 import BigNumber from "bignumber.js";
 import { satoshisToBitcoins } from "unchained-bitcoin";

--- a/src/components/Wallet/WalletControl.jsx
+++ b/src/components/Wallet/WalletControl.jsx
@@ -8,7 +8,6 @@ import {
   WALLET_MODES,
 } from "../../actions/walletActions";
 import { setRequiredSigners as setRequiredSignersAction } from "../../actions/transactionActions";
-import { naiveCoinSelection } from "../../utils";
 import { MAX_FETCH_UTXOS_ERRORS, MAX_TRAILING_EMPTY_NODES } from "./constants";
 
 // Components
@@ -50,13 +49,7 @@ class WalletControl extends React.Component {
     if (this.addressesAreLoaded()) {
       if (walletMode === WALLET_MODES.DEPOSIT) return <WalletDeposit />;
       if (walletMode === WALLET_MODES.SPEND)
-        return (
-          <WalletSpend
-            addNode={addNode}
-            updateNode={updateNode}
-            coinSelection={naiveCoinSelection}
-          />
-        );
+        return <WalletSpend addNode={addNode} updateNode={updateNode} />;
       if (walletMode === WALLET_MODES.VIEW) return <SlicesTableContainer />;
       return "";
     }

--- a/src/components/Wallet/WalletGenerator.jsx
+++ b/src/components/Wallet/WalletGenerator.jsx
@@ -58,7 +58,6 @@ class WalletGenerator extends React.Component {
 
   componentDidMount() {
     const {
-      setIsWallet,
       refreshNodes,
       common: { nodesLoaded },
       setGenerating,
@@ -68,20 +67,29 @@ class WalletGenerator extends React.Component {
       500,
       { trailing: true, leading: false }
     );
-    setIsWallet();
     refreshNodes(this.refreshNodes);
     if (nodesLoaded) setGenerating(true);
   }
 
   async componentDidUpdate(prevProps) {
     const prevPassword = prevProps.client.password;
-    const { setPasswordError, network, client } = this.props;
+    const {
+      setPasswordError,
+      network,
+      client,
+      common: { nodesLoaded },
+      setIsWallet,
+    } = this.props;
     // if the password was updated
     if (prevPassword !== client.password && client.password.length) {
       // test the connection using the set password
       // but only if the password field hasn't been changed for 500ms
       this.debouncedTestConnection({ network, client, setPasswordError });
     }
+
+    // make sure the spend view knows it's a wallet view once nodes
+    // are loaded
+    if (!prevProps.common.nodesLoaded && nodesLoaded) setIsWallet();
   }
 
   title = () => {

--- a/src/components/Wallet/WalletSpend.jsx
+++ b/src/components/Wallet/WalletSpend.jsx
@@ -47,28 +47,26 @@ class WalletSpend extends React.Component {
 
   feeAmount = new BigNumber(0);
 
-  componentDidMount = () => {
-    const { changeNode, setChangeAddress, autoSpend } = this.props;
-    if (autoSpend) setChangeAddress(changeNode.multisig.address);
-  };
+  // componentDidMount = () => {
+  //   const { changeNode, setChangeAddress, autoSpend } = this.props;
+  //   if (autoSpend) setChangeAddress(changeNode.multisig.address);
+  // };
 
-  componentDidUpdate() {
-    const { autoSpend, finalizedOutputs } = this.props;
-    if (autoSpend && !finalizedOutputs) {
-      setTimeout(this.selectCoins, 0);
-    }
-  }
+  // componentDidUpdate() {
+  //   const { autoSpend, finalizedOutputs } = this.props;
+  //   if (autoSpend && !finalizedOutputs) {
+  //     setTimeout(this.selectCoins, 0);
+  //   }
+  // }
 
   previewDisabled = () => {
     const {
       finalizedOutputs,
       outputs,
-      inputs,
       feeRateError,
       feeError,
       balanceError,
     } = this.props;
-    if (inputs.length === 0) return true;
     if (finalizedOutputs || feeRateError || feeError || balanceError) {
       return true;
     }
@@ -268,7 +266,6 @@ WalletSpend.propTypes = {
     })
   ).isRequired,
   resetNodesSpend: PropTypes.func.isRequired,
-  setChangeAddress: PropTypes.func.isRequired,
   setInputs: PropTypes.func.isRequired,
   setFeeRate: PropTypes.func.isRequired,
   setSpendStep: PropTypes.func.isRequired,

--- a/src/components/Wallet/WalletSpend.jsx
+++ b/src/components/Wallet/WalletSpend.jsx
@@ -164,6 +164,11 @@ class WalletSpend extends React.Component {
       updateNode,
       addNode,
       spendingStep,
+      fee,
+      feeRate,
+      inputs,
+      inputsTotalSats,
+      outputs,
     } = this.props;
 
     return (
@@ -216,7 +221,12 @@ class WalletSpend extends React.Component {
                   <TransactionPreview
                     changeAddress={changeAddress}
                     editTransaction={this.showCreate}
-                    showSignTransaction={this.showSignTransaction}
+                    fee={fee}
+                    feeRate={feeRate}
+                    inputs={inputs}
+                    inputsTotalSats={inputsTotalSats}
+                    outputs={outputs}
+                    handleSignTransaction={() => this.showSignTransaction()}
                   />
                 </Box>
               </Grid>
@@ -248,6 +258,7 @@ WalletSpend.propTypes = {
   finalizeOutputs: PropTypes.func.isRequired,
   finalizedOutputs: PropTypes.bool,
   inputs: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+  inputsTotalSats: PropTypes.string.isRequired,
   outputs: PropTypes.arrayOf(
     PropTypes.shape({
       address: PropTypes.string,

--- a/src/proptypes/index.js
+++ b/src/proptypes/index.js
@@ -1,3 +1,4 @@
 export { default as slicePropTypes } from "./slice";
 export { default as clientPropTypes } from "./client";
 export { default as settingsPropTypes } from "./settings";
+export { default as utilsPropTypes } from "./utils";

--- a/src/proptypes/slice.js
+++ b/src/proptypes/slice.js
@@ -1,4 +1,5 @@
 import PropTypes from "prop-types";
+import { bigNumberPropTypes } from "./utils";
 
 const slicePropTypes = {
   present: PropTypes.bool,
@@ -6,11 +7,7 @@ const slicePropTypes = {
   publicKeys: PropTypes.array,
   multisig: PropTypes.shape({}),
   address: PropTypes.string.isRequired,
-  balanceSats: PropTypes.shape({
-    s: PropTypes.number,
-    e: PropTypes.number,
-    c: PropTypes.array,
-  }),
+  balanceSats: PropTypes.shape(bigNumberPropTypes),
   utxos: PropTypes.array,
   change: PropTypes.bool.isRequired,
   spend: PropTypes.bool.isRequired,

--- a/src/proptypes/utils.js
+++ b/src/proptypes/utils.js
@@ -1,0 +1,11 @@
+import PropTypes from "prop-types";
+
+export const bigNumberPropTypes = {
+  c: PropTypes.arrayOf(PropTypes.number).isRequired,
+  e: PropTypes.number.isRequired,
+  s: PropTypes.number.isRequired,
+};
+
+export default {
+  bigNumberPropTypes,
+};

--- a/src/reducers/transactionReducer.js
+++ b/src/reducers/transactionReducer.js
@@ -232,11 +232,11 @@ function updateOutputAmount(state, action) {
   const newOutputs = [...state.outputs];
   let amount = action.value;
   const amountSats = bitcoinsToSatoshis(BigNumber(amount));
-  let error = state.inputs.length
-    ? validateOutputAmount(amountSats, state.inputsTotalSats)
-    : "";
+  let error = validateOutputAmount(amountSats, state.inputsTotalSats);
+
+  if (state.isWallet && error === "Total input amount must be positive.")
+    error = "";
   if (state.isWallet && error === "Output amount is too large.") error = "";
-  if (state.isWallet && action.number === state.changeOutputIndex) error = "";
 
   const dp = BigNumber(amount).dp();
   if (dp > 8) amount = amount.slice(0, 8 - dp);
@@ -276,24 +276,12 @@ function updateSigningKey(state, action) {
 }
 
 function outputInitialStateForMode(state) {
-  let newState = updateState(state, {
+  return updateState(state, {
     outputs: initialOutputsState(),
     fee: "",
     balanceError: "",
     changeOutputIndex: 0,
   });
-
-  if (newState.isWallet) {
-    newState = addOutput(newState);
-    newState = updateState(newState, { changeOutputIndex: 2 });
-    newState = updateOutputAmount(newState, { number: 2, value: "0" });
-    newState = updateOutputAddress(newState, {
-      number: 2,
-      value: newState.changeAddress,
-    });
-  }
-
-  return newState;
 }
 
 function resetTransactionState(state) {

--- a/src/reducers/transactionReducer.test.js
+++ b/src/reducers/transactionReducer.test.js
@@ -125,7 +125,7 @@ describe("Test transactionReducer", () => {
 
   describe("Test SET_OUTPUT_ADDRESS action", () => {
     it("should properly set output address", () => {
-      const initial = { ...initialOutputState };
+      const initial = initialOutputState();
       const address = "2MzZgrQq6Qa7U1p24eNx6N2wrpCr8bEpdeH";
       const r = reducer(
         {
@@ -142,13 +142,13 @@ describe("Test transactionReducer", () => {
     });
 
     it("should properly reject duplicate output address", () => {
-      const initial = { ...initialOutputState };
+      const initial = initialOutputState();
       const address = "2MzZgrQq6Qa7U1p24eNx6N2wrpCr8bEpdeH";
       initial.address = address;
       const r = reducer(
         {
           inputs: [],
-          outputs: [{ address }, { ...initialOutputState }],
+          outputs: [{ address }, initialOutputState()],
           network: TESTNET,
         },
         {
@@ -161,14 +161,14 @@ describe("Test transactionReducer", () => {
     });
 
     it("should properly reject output address equal to input address", () => {
-      const initial = { ...initialOutputState };
+      const initial = initialOutputState();
       const address = "2MzZgrQq6Qa7U1p24eNx6N2wrpCr8bEpdeH";
       initial.address = address;
       const input = { multisig: { address } };
       const r = reducer(
         {
           inputs: [input],
-          outputs: [{ ...initialOutputState }],
+          outputs: [initialOutputState()],
           network: TESTNET,
         },
         {
@@ -185,7 +185,7 @@ describe("Test transactionReducer", () => {
 
   describe("Test SET_OUTPUT_AMOUNT action", () => {
     it("should properly set output amount", () => {
-      const initial = { ...initialOutputState };
+      const initial = initialOutputState();
       const r = reducer(
         {
           inputs: [],
@@ -203,14 +203,7 @@ describe("Test transactionReducer", () => {
 
   describe("Test DELETE_OUTPUT action", () => {
     it("should properly remove an output and update fee", () => {
-      const initial = [
-        {
-          ...initialOutputState,
-        },
-        {
-          ...initialOutputState,
-        },
-      ];
+      const initial = [initialOutputState(), initialOutputState()];
       const r = reducer(
         {
           inputs: [{}],
@@ -270,7 +263,7 @@ describe("Test transactionReducer", () => {
     it("should properly set fee and update fee rate", () => {
       const r = reducer(
         {
-          ...initialState,
+          ...initialState(),
           inputs: [{}],
           outputs: [{}],
           addressType: P2WSH,
@@ -284,7 +277,6 @@ describe("Test transactionReducer", () => {
         }
       );
 
-      expect(r.feeRate).toEqual("3");
       expect(r.fee).toEqual("0.00000504");
     });
   });
@@ -297,7 +289,7 @@ describe("Test transactionReducer", () => {
       };
       const r = reducer(
         {
-          ...initialState,
+          ...initialState(),
           inputs: [
             {
               txid:
@@ -341,7 +333,7 @@ describe("Test transactionReducer", () => {
           type: RESET_OUTPUTS,
         }
       );
-      expect(r.outputs).toEqual([initialOutputState]);
+      expect(r.outputs).toEqual([initialOutputState()]);
       expect(r.fee).toEqual("");
       expect(r.balanceError).toEqual("");
     });

--- a/src/selectors/wallet.js
+++ b/src/selectors/wallet.js
@@ -84,6 +84,19 @@ export const getSlicesWithLastUsed = createSelector(
 );
 
 /**
+ * Gets the set of spendable slices, i.e. ones that don't have a
+ * pending utxo and are not spent
+ */
+export const getSpendableSlices = createSelector(
+  getSlicesWithLastUsed,
+  (slices) => {
+    return slices.filter(
+      (slice) => slice.lastUsed !== "Pending" && slice.lastUsed !== "Spent"
+    );
+  }
+);
+
+/**
  * @description Returns a selector that provides all spent slices, i.e.
  * All slices that have been used but have no balance left.
  */

--- a/src/selectors/wallet.js
+++ b/src/selectors/wallet.js
@@ -91,7 +91,10 @@ export const getSpendableSlices = createSelector(
   getSlicesWithLastUsed,
   (slices) => {
     return slices.filter(
-      (slice) => slice.lastUsed !== "Pending" && slice.lastUsed !== "Spent"
+      (slice) =>
+        slice.lastUsed !== "Pending" &&
+        slice.lastUsed !== "Spent" &&
+        slice.utxos.length
     );
   }
 );

--- a/src/selectors/wallet.js
+++ b/src/selectors/wallet.js
@@ -92,7 +92,8 @@ export const getSpendableSlices = createSelector(
   (slices) => {
     return slices.filter(
       (slice) =>
-        slice.lastUsed !== "Pending" &&
+        // pending change is considered spendable
+        (slice.lastUsed !== "Pending" || slice.change) &&
         slice.lastUsed !== "Spent" &&
         slice.utxos.length
     );

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,7 +1,8 @@
 import BigNumber from "bignumber.js";
 import { satoshisToBitcoins } from "unchained-bitcoin";
 
-export const DUST_IN_BTC = satoshisToBitcoins(BigNumber(546));
+export const DUST_IN_SATOSHIS = 546;
+export const DUST_IN_BTC = satoshisToBitcoins(BigNumber(DUST_IN_SATOSHIS));
 export const DEFAULT_PREFIX = "m";
 export const CHANGE_INDEX = "/1";
 export const DEFAULT_CHANGE_PREFIX = DEFAULT_PREFIX + CHANGE_INDEX;

--- a/src/utils/fixtures.js
+++ b/src/utils/fixtures.js
@@ -1,0 +1,78 @@
+/* eslint-disable import/prefer-default-export */
+/* eslint-disable no-param-reassign */
+import BigNumber from "bignumber.js";
+
+/**
+ * Generate a mock state with some slices and utxos with balances
+ * @param {Object} walletBalance
+ * @param {number} walletBalance.confirmedBalance
+ * @param {number} walletBalance.pendingBalance
+ */
+export function getMockState(walletBalance) {
+  const {
+    confirmedBalance,
+    pendingBalance,
+    numConfirmed = 5,
+    numPending = 2,
+  } = walletBalance;
+
+  const utxosConfirmed = Array(numConfirmed).fill({
+    confirmed: true,
+    amountSats: new BigNumber(Math.floor(confirmedBalance / numConfirmed), 10),
+    time: Date.now() - Math.floor(Math.random() * 10000),
+  });
+
+  const utxosUnconfirmed =
+    numPending && pendingBalance
+      ? Array(numPending).fill({
+          confirmed: false,
+          amountSats: new BigNumber(
+            Math.floor(pendingBalance / numPending),
+            10
+          ),
+        })
+      : [];
+
+  // we'll put half of the confirmed utxos in a deposit slice
+  // and half in change. All unconfirmed will go in one deposit slice
+  const state = {
+    wallet: {
+      deposits: {
+        nodes: [
+          {
+            utxos: utxosConfirmed.slice(Math.floor(utxosConfirmed.length / 2)),
+            change: false,
+          },
+          {
+            utxos: utxosUnconfirmed,
+            change: false,
+          },
+        ],
+      },
+      change: {
+        nodes: [
+          {
+            utxos: utxosConfirmed.slice(Math.ceil(utxosConfirmed.length / 2)),
+            change: true,
+          },
+        ],
+      },
+    },
+  };
+
+  // set slice balances
+  state.wallet.deposits.nodes.forEach((slice) => {
+    slice.balanceSats = slice.utxos.reduce((balance, utxo) => {
+      if (utxo.confirmed) return balance.plus(utxo.amountSats);
+      return balance;
+    }, new BigNumber(0));
+  });
+
+  state.wallet.change.nodes.forEach((slice) => {
+    slice.balanceSats = slice.utxos.reduce((balance, utxo) => {
+      if (utxo.confirmed) return balance.plus(utxo.amountSats);
+      return balance;
+    }, new BigNumber(0));
+  });
+  return state;
+}

--- a/src/utils/fixtures.js
+++ b/src/utils/fixtures.js
@@ -33,8 +33,8 @@ export function getMockState(walletBalance) {
         })
       : [];
 
-  // we'll put half of the confirmed utxos in a deposit slice
-  // and half in change. All unconfirmed will go in one deposit slice
+  // we'll put half of the confirmed and unconfirme utxos in a deposit slice
+  // and half in change.
   const state = {
     wallet: {
       deposits: {
@@ -44,7 +44,9 @@ export function getMockState(walletBalance) {
             change: false,
           },
           {
-            utxos: utxosUnconfirmed,
+            utxos: utxosUnconfirmed.slice(
+              Math.floor(utxosUnconfirmed.length / 2)
+            ),
             change: false,
           },
         ],
@@ -55,6 +57,12 @@ export function getMockState(walletBalance) {
             utxos: utxosConfirmed.slice(Math.ceil(utxosConfirmed.length / 2)),
             change: true,
           },
+          {
+            utxos: utxosUnconfirmed.slice(
+              Math.ceil(utxosUnconfirmed.length / 2)
+            ),
+            change: true,
+          },
         ],
       },
     },
@@ -62,17 +70,17 @@ export function getMockState(walletBalance) {
 
   // set slice balances
   state.wallet.deposits.nodes.forEach((slice) => {
-    slice.balanceSats = slice.utxos.reduce((balance, utxo) => {
-      if (utxo.confirmed) return balance.plus(utxo.amountSats);
-      return balance;
-    }, new BigNumber(0));
+    slice.balanceSats = slice.utxos.reduce(
+      (balance, utxo) => balance.plus(utxo.amountSats),
+      new BigNumber(0)
+    );
   });
 
   state.wallet.change.nodes.forEach((slice) => {
-    slice.balanceSats = slice.utxos.reduce((balance, utxo) => {
-      if (utxo.confirmed) return balance.plus(utxo.amountSats);
-      return balance;
-    }, new BigNumber(0));
+    slice.balanceSats = slice.utxos.reduce(
+      (balance, utxo) => balance.plus(utxo.amountSats),
+      new BigNumber(0)
+    );
   });
   return state;
 }

--- a/src/utils/index.jsx
+++ b/src/utils/index.jsx
@@ -1,5 +1,8 @@
 import React from "react";
 import BigNumber from "bignumber.js";
+import { estimateMultisigTransactionFee } from "unchained-bitcoin/lib/fees";
+
+import { DUST_IN_SATOSHIS } from "./constants";
 
 export function externalLink(url, text) {
   return (
@@ -86,4 +89,40 @@ export function naiveCoinSelection(spendableInputs, outputTotal) {
     }
   }
   return selectedUtxos;
+}
+
+/**
+ * @description A utility function to determine if a spend is a valid
+ * "spend all" transaction,
+ * @param {Object} options - set of options used to determine if is spend all
+ * @param {Object[]} options.outputs
+ * @param {string} options.outputs[].amountSats
+ * @param {string|number} options.walletBalance
+ * @param {string} options.feesPerByteInSatoshis
+ * @param {number} options.numInputs
+ * @param {string} options.addressType
+ * @param {number} options.m
+ * @param {number} options.n
+ * @returns {boolean} whether or not conditions are met to be "spendAll"
+ */
+export function isSpendAll(options) {
+  const config = {
+    ...options,
+    numOutputs: options.outputs.length,
+  };
+  const estimatedFees = estimateMultisigTransactionFee(config).toNumber();
+  const outputTotal = config.outputs.reduce((balance, output) => {
+    const amountSats = parseInt(output.amountSats, 10);
+    // eslint-disable-next-line no-param-reassign
+    balance += amountSats;
+    return balance;
+  }, 0);
+
+  if (outputTotal + estimatedFees > options.walletBalance)
+    throw new Error("Wallet balance is insufficient to fund transaction");
+
+  if (outputTotal + estimatedFees + DUST_IN_SATOSHIS < options.walletBalance)
+    return false;
+
+  return true;
 }

--- a/src/utils/utils.test.js
+++ b/src/utils/utils.test.js
@@ -1,0 +1,97 @@
+import assert from "assert";
+import {
+  TEST_FIXTURES,
+  estimateMultisigTransactionFee,
+} from "unchained-bitcoin";
+
+import { DUST_IN_SATOSHIS } from "./constants";
+import { isSpendAll } from "./index";
+
+function getConfig(fixture, feeRate) {
+  const {
+    type: addressType,
+    multisig,
+    transaction: { outputs },
+    utxos,
+  } = fixture;
+  const numInputs = utxos.length;
+  const numOutputs = outputs.length;
+
+  // p2sh-p2wsh has m/n embedeed so need to go two scripts deep
+  const { m, n } = multisig.redeem.redeem
+    ? multisig.redeem.redeem
+    : multisig.redeem;
+
+  const outputTotal = outputs.reduce((balance, output) => {
+    const amountSats = parseInt(output.amountSats, 10);
+    // eslint-disable-next-line no-param-reassign
+    balance += amountSats;
+    return balance;
+  }, 0);
+
+  return {
+    addressType,
+    outputs,
+    numInputs,
+    numOutputs,
+    m,
+    n,
+    feesPerByteInSatoshis: feeRate,
+    outputTotal,
+  };
+}
+
+describe("utils", () => {
+  describe("isSpendAll", () => {
+    const feesPerByteInSatoshis = "10";
+    it("should correctly identify a spend all tx", () => {
+      TEST_FIXTURES.multisigs.forEach((fixture) => {
+        const config = getConfig(fixture, feesPerByteInSatoshis);
+        const fees = estimateMultisigTransactionFee(config).toNumber();
+
+        // for a spendAll tx, the diff between wallet balance minus fees and output amount
+        // should be less than dust limit
+        let walletBalance = config.outputTotal + fees;
+        const { addressType, numInputs, numOutputs } = config;
+
+        // this would be a perfect spend all where the difference between
+        // wallet balance and outputs is equal to fees
+        assert.equal(
+          isSpendAll({ ...config, walletBalance }),
+          true,
+          `Should be true for ${addressType}, ${numInputs} inputs and ${numOutputs} outputs`
+        );
+        // check for a difference that is less than dust amount
+        walletBalance += Math.ceil(DUST_IN_SATOSHIS / 2);
+
+        assert.equal(
+          isSpendAll({ ...config, walletBalance }),
+          true,
+          `Should be true for ${addressType}, ${numInputs} inputs and ${numOutputs} outputs when difference is dust`
+        );
+      });
+    });
+
+    it("should correctly identify a tx that is not spending all inputs", () => {
+      TEST_FIXTURES.multisigs.forEach((fixture) => {
+        const config = getConfig(fixture, feesPerByteInSatoshis);
+        const walletBalance = config.outputTotal * 2;
+        assert.equal(
+          isSpendAll({ ...config, walletBalance }),
+          false,
+          `Should be false for ${config.addressType}, ${walletBalance} wallet balance and ${config.outputTotal} output value`
+        );
+      });
+    });
+
+    it("should throw if walletBalance is not enough to cover outputs and fees", () => {
+      TEST_FIXTURES.multisigs.forEach((fixture) => {
+        const config = getConfig(fixture, feesPerByteInSatoshis);
+        const fees = estimateMultisigTransactionFee(config).toNumber();
+        const walletBalance = config.outputTotal - fees;
+        const test = () => isSpendAll({ ...config, walletBalance });
+        expect(test).toThrow();
+      });
+    });
+  });
+});

--- a/src/utils/utils.test.js
+++ b/src/utils/utils.test.js
@@ -1,11 +1,15 @@
 import assert from "assert";
+import BigNumber from "bignumber.js";
 import {
   TEST_FIXTURES,
   estimateMultisigTransactionFee,
+  P2WSH,
 } from "unchained-bitcoin";
 
 import { DUST_IN_SATOSHIS } from "./constants";
-import { isSpendAll } from "./index";
+import { isSpendAll, naiveCoinSelection } from "./index";
+import { getMockState } from "./fixtures";
+import { getSpendableSlices } from "../selectors/wallet";
 
 function getConfig(fixture, feeRate) {
   const {
@@ -23,11 +27,8 @@ function getConfig(fixture, feeRate) {
     : multisig.redeem;
 
   const outputTotal = outputs.reduce((balance, output) => {
-    const amountSats = parseInt(output.amountSats, 10);
-    // eslint-disable-next-line no-param-reassign
-    balance += amountSats;
-    return balance;
-  }, 0);
+    return balance.plus(output.amountSats);
+  }, new BigNumber(0));
 
   return {
     addressType,
@@ -51,7 +52,7 @@ describe("utils", () => {
 
         // for a spendAll tx, the diff between wallet balance minus fees and output amount
         // should be less than dust limit
-        let walletBalance = config.outputTotal + fees;
+        let walletBalance = config.outputTotal.plus(fees);
         const { addressType, numInputs, numOutputs } = config;
 
         // this would be a perfect spend all where the difference between
@@ -62,7 +63,7 @@ describe("utils", () => {
           `Should be true for ${addressType}, ${numInputs} inputs and ${numOutputs} outputs`
         );
         // check for a difference that is less than dust amount
-        walletBalance += Math.ceil(DUST_IN_SATOSHIS / 2);
+        walletBalance = walletBalance.plus(Math.ceil(DUST_IN_SATOSHIS / 2));
 
         assert.equal(
           isSpendAll({ ...config, walletBalance }),
@@ -75,7 +76,7 @@ describe("utils", () => {
     it("should correctly identify a tx that is not spending all inputs", () => {
       TEST_FIXTURES.multisigs.forEach((fixture) => {
         const config = getConfig(fixture, feesPerByteInSatoshis);
-        const walletBalance = config.outputTotal * 2;
+        const walletBalance = config.outputTotal.multipliedBy(2).toFixed();
         assert.equal(
           isSpendAll({ ...config, walletBalance }),
           false,
@@ -88,10 +89,167 @@ describe("utils", () => {
       TEST_FIXTURES.multisigs.forEach((fixture) => {
         const config = getConfig(fixture, feesPerByteInSatoshis);
         const fees = estimateMultisigTransactionFee(config).toNumber();
-        const walletBalance = config.outputTotal - fees;
+        const walletBalance = config.outputTotal.minus(fees);
         const test = () => isSpendAll({ ...config, walletBalance });
         expect(test).toThrow();
       });
+    });
+  });
+
+  describe("naiveCoinSelection", () => {
+    let state;
+    let slices;
+    let options;
+    let walletBalance;
+    let output;
+    let totalUtxoCount;
+
+    beforeEach(() => {
+      state = getMockState({ confirmedBalance: 100000 });
+      slices = getSpendableSlices(state);
+      walletBalance = slices.reduce(
+        (balance, slice) => balance.plus(slice.balanceSats),
+        new BigNumber(0)
+      );
+      totalUtxoCount = slices.reduce(
+        (count, slice) => count + slice.utxos.length,
+        0
+      );
+      output = {
+        // testnet faucet address
+        address: "2NGZrVvZG92qGYqzTLjCAewvPZ7JE8S8VxE",
+        amountSats: "0",
+      };
+
+      options = {
+        addressType: P2WSH,
+        slices,
+        m: 2,
+        n: 2,
+        feesPerByteInSatoshis: 3,
+        outputs: [],
+      };
+    });
+
+    it("should return full set of all spendable utxos if is a spendAll tx", () => {
+      // test with a tx that has one output with value equal to total value
+      // of spendable slices minus fees
+      const fee = estimateMultisigTransactionFee({
+        ...options,
+        numInputs: totalUtxoCount,
+        numOutputs: 1,
+      });
+      output.amountSats = walletBalance.minus(fee).toFixed();
+      options.outputs = [output];
+      let [inputs, changeRequired] = naiveCoinSelection(options);
+      expect(inputs).toHaveLength(totalUtxoCount);
+      expect(changeRequired).toBe(false);
+
+      // the result should be the same if the difference between output value
+      // and wallet balance is fee plus dust
+      output.amountSats = walletBalance
+        .minus(fee)
+        .minus(DUST_IN_SATOSHIS / 2)
+        .toFixed();
+      options.outputs = [output];
+      [inputs, changeRequired] = naiveCoinSelection(options);
+      expect(inputs).toHaveLength(totalUtxoCount);
+      expect(changeRequired).toBe(false);
+    });
+
+    it("should return a valid set of inputs and no change when possible", () => {
+      // naive coin selection just adds slice utxos in the order that they appear
+      // so to test a no-change tx, we want to come up with an output value
+      // that is equal to the first slice balances minus fees
+      const slice = slices[0];
+      const utxoCount = slice.utxos.length;
+      const fee = estimateMultisigTransactionFee({
+        ...options,
+        numInputs: utxoCount,
+        numOutputs: 1,
+      });
+      output.amountSats = slice.balanceSats.minus(fee).toFixed();
+      options.outputs = [output];
+
+      // calculate for comparisons in tests
+      const expectedInputsTotal = new BigNumber(output.amountSats)
+        .plus(fee)
+        .toFixed();
+
+      let [inputs, changeRequired] = naiveCoinSelection(options);
+      let inputsTotal = inputs.reduce(
+        (total, input) => total.plus(input.amountSats),
+        new BigNumber(0)
+      );
+
+      expect(inputs).toHaveLength(utxoCount);
+      expect(changeRequired).toBe(false);
+      // confirm that the inputs add up to the expected amount
+      expect(inputsTotal.toFixed()).toEqual(expectedInputsTotal);
+
+      // the result should be the same if the difference between output value
+      // and slice balance is fee plus dust
+      output.amountSats = slice.balanceSats
+        .minus(fee)
+        .minus(DUST_IN_SATOSHIS / 2)
+        .toFixed();
+      options.outputs = [output];
+      [inputs, changeRequired] = naiveCoinSelection(options);
+      expect(inputs).toHaveLength(utxoCount);
+      expect(changeRequired).toBe(false);
+      inputsTotal = inputs.reduce(
+        (total, input) => total.plus(input.amountSats),
+        new BigNumber(0)
+      );
+
+      // confirm that the inputs add up to the expected amount
+      expect(inputsTotal.toFixed()).toEqual(expectedInputsTotal);
+    });
+
+    it("should return a valid set of inputs with change when necessary", () => {
+      // going to use both spendable slices for this one but the output value
+      // should be greater than dust and less than balance of second slice so that
+      // we can expect change to be required.
+      const fee = estimateMultisigTransactionFee({
+        ...options,
+        numInputs: totalUtxoCount,
+        numOutputs: 1,
+      });
+
+      // half the second slice balance plus the whole first slice balance
+      output.amountSats = slices[1].balanceSats
+        .dividedBy(2)
+        .plus(slices[0].balanceSats)
+        .toFixed();
+
+      const slicesBalance = slices[0].balanceSats.plus(slices[1].balanceSats);
+
+      // sanity check, esp in case fixtures change for some reason
+      assert(
+        slicesBalance
+          .minus(fee)
+          .minus(output.amountSats)
+          .isGreaterThan(DUST_IN_SATOSHIS),
+        `Test slices balance amount minus fee and output 
+ should be greater than dust so that change is required`
+      );
+
+      options.outputs = [output];
+
+      const [inputs, changeRequired] = naiveCoinSelection(options);
+
+      // should be using all utxos
+      expect(inputs).toHaveLength(
+        slices[0].utxos.length + slices[1].utxos.length
+      );
+      expect(changeRequired).toBe(true);
+    });
+
+    it("should throw if available balance is not enough to fund the outputs", () => {
+      output.amountSats = walletBalance.plus(1000);
+      options.outputs = [output];
+      const test = () => naiveCoinSelection(options);
+      expect(test).toThrow();
     });
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## PR Type

<!---
  What types of change(s) does your code introduce?
  Put an `x` in all the boxes that apply:
-->

* [x] Bug fix
* [ ] Feature
* [x] Code style update (whitespace, formatting, missing semicolons, etc.)
* [x] Refactor (i.e., no functional changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation changes
* [ ] Other (please describe below):

## Description
This is a rewrite of the spend UX and includes a re-factor of the coin selection functionality. With this new update, coin selection (and fee calculation) happens after outputs have been selected and the user clicks to preview the transaction. This should fix several bugs that seem related to some race conditions if the view was changed while a tx was being composed in auto spend mode. 

<!---
  Please describe your change(s) in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

## Does this PR introduce a breaking change?

<!--
  If this PR contains a breaking change,
  please also describe the impact and migration path for existing applications
-->
This should not introduce a breaking change, but the whole spend flow will need to be tested thoroughly, including manual mode and from the script explorer. 
* [ ] Yes
* [x] No

## Does this PR fixes open issues?

<!-- If this PR contain fixes to open issues please link them here -->

* [ ] Yes
* [x] No
