### PR TITLE
docs(other): remove PR type from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,21 +1,5 @@
 <!--- Provide a general summary of your changes in the Title above -->
 
-## PR Type
-
-<!---
-  What types of change(s) does your code introduce?
-  Put an `x` in all the boxes that apply:
--->
-
-* [ ] Bug fix
-* [ ] Feature
-* [ ] Code style update (whitespace, formatting, missing semicolons, etc.)
-* [ ] Refactor (i.e., no functional changes)
-* [ ] Build related changes
-* [ ] CI related changes
-* [ ] Documentation changes
-* [ ] Other (please describe below):
-
 ## Description
 
 <!---


### PR DESCRIPTION
## Description
Now that we're using commitizen we don't need the first part of
the PR template.  Removing to make it shorter.

<!---
  Please describe your change(s) in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

## Does this PR introduce a breaking change?

<!--
  If this PR contains a breaking change,
  please also describe the impact and migration path for existing applications
-->

* [ ] Yes
* [ ] No

## Does this PR fixes open issues?

<!-- If this PR contain fixes to open issues please link them here -->

* [ ] Yes
* [ ] No
