### PR TITLE
 fix(wallet): update spending slices when WalletSign component unmounts

### DIFF
--- a/src/actions/walletActions.jsx
+++ b/src/actions/walletActions.jsx
@@ -163,6 +163,9 @@ export function spendSlices(inputs, changeSlice) {
       spend: {
         transaction: { changeAddress },
       },
+      wallet: {
+        deposits: { nextNode },
+      },
     } = getState();
 
     const sliceUpdates = [];
@@ -195,6 +198,13 @@ export function spendSlices(inputs, changeSlice) {
       addressSet.add(changeAddress);
       sliceUpdates.push(fetchSliceStatus(changeAddress, changeSlice.bip32Path));
     }
+
+    // check the next deposit slice just in case a spend is to own wallet
+    // this doesn't catch all self-spend cases but should catch the majority
+    // to avoid any confusion for less technical users.
+    sliceUpdates.push(
+      fetchSliceStatus(nextNode.multisig.address, nextNode.bip32Path)
+    );
 
     const updatedSlices = await Promise.all(sliceUpdates);
 

--- a/src/components/Wallet/WalletSign.jsx
+++ b/src/components/Wallet/WalletSign.jsx
@@ -31,9 +31,19 @@ class WalletSign extends React.Component {
   }
 
   componentWillUnmount() {
-    const { resetTransaction } = this.props;
+    const {
+      resetTransaction,
+      transaction,
+      changeSlice,
+      spendSlices,
+    } = this.props;
     const { spent } = this.state;
-    if (spent) resetTransaction();
+    if (spent) {
+      // have a brief delay to make sure the queried node had enough time
+      // to update
+      setTimeout(() => spendSlices(transaction.inputs, changeSlice), 1000);
+      resetTransaction();
+    }
   }
 
   render = () => {
@@ -110,12 +120,7 @@ class WalletSign extends React.Component {
   };
 
   transactionFinalized = () => {
-    const {
-      transaction,
-      spendSlices,
-      changeSlice,
-      updateChangeNode,
-    } = this.props;
+    const { transaction, changeSlice, updateChangeNode } = this.props;
 
     const { txid } = transaction;
     const { spent } = this.state;
@@ -131,7 +136,6 @@ class WalletSign extends React.Component {
           break;
         }
       }
-      spendSlices(transaction.inputs, changeSlice);
       return true;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## PR Type

<!---
  What types of change(s) does your code introduce?
  Put an `x` in all the boxes that apply:
-->

* [x] Bug fix
* [x] Feature
* [ ] Code style update (whitespace, formatting, missing semicolons, etc.)
* [ ] Refactor (i.e., no functional changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation changes
* [ ] Other (please describe below):

## Description
Only update the spend transaction slices after the transaction confirmation/preview component has unmounted. This gives querying node enough time to update its mempool state and return accurate information about the queried slices. 

This also adds a small upgrade to include the next deposit slice in this update step. This means that self-spends to your own wallet (as long as it's the latest address from the receive tab) will be reflected in the UI without a refresh. 

<!---
  Please describe your change(s) in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

## Does this PR introduce a breaking change?

<!--
  If this PR contains a breaking change,
  please also describe the impact and migration path for existing applications
-->

* [ ] Yes
* [x] No

## Does this PR fixes open issues?

<!-- If this PR contain fixes to open issues please link them here -->

* [ ] Yes
* [x] No
