### PR TITLE
fix(wallet): fixes display error in totals when switching b/w spend modes

### DIFF
--- a/src/components/Wallet/WalletSpend.jsx
+++ b/src/components/Wallet/WalletSpend.jsx
@@ -124,8 +124,11 @@ class WalletSpend extends React.Component {
   };
 
   handleSpendMode = (event) => {
-    const { updateAutoSpend } = this.props;
+    const { updateAutoSpend, resetNodesSpend, deleteChangeOutput } = this.props;
     updateAutoSpend(!event.target.checked);
+    updateAutoSpend(!event.target.checked);
+    resetNodesSpend();
+    deleteChangeOutput();
   };
 
   render() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
clears inputs and change when switching between spend modes as these don't translate between the two states and can distort calculations for tx values. 

<!---
  Please describe your change(s) in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

## Does this PR introduce a breaking change?

<!--
  If this PR contains a breaking change,
  please also describe the impact and migration path for existing applications
-->

* [ ] Yes
* [x] No

## Does this PR fixes open issues?

<!-- If this PR contain fixes to open issues please link them here -->

* [ ] Yes
* [x] No
