### PR TITLE
fix(other): update menu links to open in new tab

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -39,7 +39,12 @@ class NavItem extends React.Component {
   render() {
     const { href, title, classes, handleClose } = this.props;
     return (
-      <a href={href} className={classes.menuLink}>
+      <a
+        href={href}
+        className={classes.menuLink}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
         <MenuItem className={classes.menuItem} onClick={handleClose}>
           {title}
         </MenuItem>


### PR DESCRIPTION
## Description

This change adds `target="_blank" rel="noopener noreferrer"` to all menu item links to ensure they open in a new tab without erasing the state of Caravan in the current tab.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

## Does this PR fixes open issues?

* [x] Yes
* [ ] No

https://github.com/unchained-capital/caravan/issues/102
