### PR TITLE
fix(wallet): fixes inconsistencies in wallet balance update after spend

### DIFF
--- a/src/actions/walletActions.js
+++ b/src/actions/walletActions.js
@@ -14,7 +14,10 @@ import {
   setFee,
   finalizeOutputs,
 } from "./transactionActions";
-import { setErrorNotification } from "./errorNotificationActions";
+import {
+  setErrorNotification,
+  clearErrorNotification,
+} from "./errorNotificationActions";
 import { getSpendableSlices } from "../selectors/wallet";
 
 export const UPDATE_DEPOSIT_SLICE = "UPDATE_DEPOSIT_SLICE";
@@ -161,7 +164,11 @@ export function autoSelectCoins() {
  * the slices being used in the spend tx and update them once changed state is confirmed.
  * @param {Object} changeSlice - the slice that was chosen as the change output
  */
-export function updateTxSlices(changeSlice, retries = 5) {
+export function updateTxSlices(
+  changeSlice,
+  retries = 10,
+  skipAddresses = new Set()
+) {
   return async (dispatch, getState) => {
     const {
       settings: { network },
@@ -170,85 +177,108 @@ export function updateTxSlices(changeSlice, retries = 5) {
         transaction: { changeAddress, inputs, txid },
       },
       wallet: {
-        deposits: { nextNode, nodes: depositNodes },
-        change: { nodes: changeNodes },
+        deposits: { nextNode: nextDepositSlice, nodes: depositSlices },
+        change: { nodes: changeSlices },
       },
     } = getState();
 
-    const sliceUpdates = [];
-
-    // track which slices are already being queried since
-    // the fetch command will get all utxos for an address.
-    const addressSet = new Set();
+    // utility function for getting utxo set of an address
+    // and formatting the result in a way we can use
     const fetchSliceStatus = async (address, bip32Path) => {
       const utxos = await fetchAddressUTXOs(address, network, client);
       return {
         addressUsed: true,
         change: isChange(bip32Path),
+        address,
         bip32Path,
         ...utxos,
       };
     };
 
-    inputs.forEach((input) => {
-      const { address } = input.multisig;
-      if (!addressSet.has(address)) {
+    // array of slices we want to query
+    const slices = [...inputs];
+
+    // if there is a change address in the transaction
+    // then we want to query the state of that slice as well
+    if (changeSlice && changeSlice.multisig.address === changeAddress) {
+      slices.push(changeSlice);
+    }
+
+    // array to store results from queries for each slice
+    const sliceUpdates = [];
+
+    // track which slices are already being queried since
+    // the fetch command will get all utxos for an address
+    // and some inputs might be for the same address
+    const addressSet = new Set();
+
+    // go through each slice and see if it needs to be queried
+    slices.forEach((slice) => {
+      const { address } = slice.multisig;
+      // if address isn't already being queried and isn't in the
+      // set of addresses to skip (which means it's already been
+      // successfully updated), then fetchSliceStatus
+      if (!addressSet.has(address) && !skipAddresses.has(address)) {
         addressSet.add(address);
         // setting up async network calls to await all of them
-        sliceUpdates.push(fetchSliceStatus(address, input.bip32Path));
+        sliceUpdates.push(fetchSliceStatus(address, slice.bip32Path));
       }
     });
 
-    // if we have a change slice and it matches the change address in the transaction
-    // then let's query an update for that slice too
-    if (changeSlice && changeSlice.multisig.address === changeAddress) {
-      addressSet.add(changeAddress);
-      sliceUpdates.push(fetchSliceStatus(changeAddress, changeSlice.bip32Path));
+    // once all queries have completed we can confirm which have been updated
+    const queriedSlices = await Promise.all(sliceUpdates);
+
+    for (let i = 0; i < queriedSlices.length; i += 1) {
+      const slice = queriedSlices[i];
+      const utxoCount = slice.change
+        ? changeSlices[slice.bip32Path].utxos.length
+        : depositSlices[slice.bip32Path].utxos.length;
+
+      // if the utxo count is not the same then we can reliably update
+      // this slice and can skip in any future calls
+      if (slice && slice.utxos && slice.utxos.length !== utxoCount) {
+        dispatch({
+          type: slice.change ? UPDATE_CHANGE_SLICE : UPDATE_DEPOSIT_SLICE,
+          value: slice,
+        });
+        skipAddresses.add(slice.address);
+      }
     }
 
-    // check the next deposit slice just in case a spend is to own wallet
-    // this doesn't catch all self-spend cases but should catch the majority
-    // to avoid any confusion for less technical users.
-    sliceUpdates.push(
-      fetchSliceStatus(nextNode.multisig.address, nextNode.bip32Path)
-    );
-
-    const updatedSlices = await Promise.all(sliceUpdates);
-    const firstSlice = updatedSlices[0];
-    const utxoCount = firstSlice.change
-      ? changeNodes[firstSlice.bip32Path].utxos.length
-      : depositNodes[firstSlice.bip32Path].utxos.length;
-
-    // want to make sure we only update the slices if they
-    // have changed states, i.e. the number utxos is different from what we have
-    // so if the slice state isn't reporting as changed after fetching
-    // we will try a few more times
-    if (firstSlice.utxos.length === utxoCount && retries)
+    // if not all slices queried were successful, then we want to recursively call
+    // updateTxSlices, counting down retries and with the full set of successful queries
+    if (skipAddresses.size !== queriedSlices.length && retries)
       return setTimeout(
-        () => dispatch(updateTxSlices(changeSlice, retries - 1)),
+        () => dispatch(updateTxSlices(changeSlice, retries - 1, skipAddresses)),
         750
       );
-
-    // if we're out of retries and counts are still the same
-    // then we're done trying and should show an error
-    if (firstSlice.utxos.length === utxoCount && !retries) {
-      let message = `There was a problem updating the wallet balance. 
+    // // if we're out of retries and counts are still the same
+    // // then we're done trying and should show an error
+    if (!retries) {
+      let message = `There was a problem updating the wallet balance.
       It is recommended you refresh the wallet to make sure UTXO current set is up to date.`;
       if (txid && txid.length) message += ` Transaction ID: ${txid}`;
       return dispatch(setErrorNotification(message));
     }
 
-    return updatedSlices.forEach((slice) => {
-      if (slice.change)
-        return dispatch({
-          type: UPDATE_CHANGE_SLICE,
-          value: { ...slice, spend: true },
-        });
-      return dispatch({
-        type: UPDATE_DEPOSIT_SLICE,
-        value: { ...slice, spend: true },
-      });
-    });
+    // check the next deposit slice just in case a spend is to own wallet
+    // this doesn't catch all self-spend cases but should catch the majority
+    // to avoid any confusion for less technical users.
+    const updatedSlice = await fetchSliceStatus(
+      nextDepositSlice.multisig.address,
+      nextDepositSlice.bip32Path
+    );
+
+    // if its status has changed and the utxo set for the next
+    // deposit slice is different, then update it as well
+    if (
+      updatedSlice.utxos.length !==
+      depositSlices[updatedSlice.bip32Path].utxos.length
+    )
+      return dispatch({ type: UPDATE_DEPOSIT_SLICE, value: updatedSlice });
+
+    dispatch(setErrorNotification("Wallet addresses updated"));
+    return setTimeout(() => dispatch(clearErrorNotification()), 2000);
   };
 }
 

--- a/src/actions/walletActions.js
+++ b/src/actions/walletActions.js
@@ -232,9 +232,8 @@ export function updateTxSlices(changeSlice, retries = 5) {
     // if we're out of retries and counts are still the same
     // then we're done trying and should show an error
     if (firstSlice.utxos.length === utxoCount && !retries) {
-      let message = `There was a problem updating the wallet. 
-It's possible your transaction did not broadcast correctly. Please confirm 
-the state of the transaction with an external block explorer, then refresh the wallet and try again.`;
+      let message = `There was a problem updating the wallet balance. 
+      It is recommended you refresh the wallet to make sure UTXO current set is up to date.`;
       if (txid && txid.length) message += ` Transaction ID: ${txid}`;
       return dispatch(setErrorNotification(message));
     }

--- a/src/components/Wallet/TransactionPreview.jsx
+++ b/src/components/Wallet/TransactionPreview.jsx
@@ -38,16 +38,17 @@ class TransactionPreview extends React.Component {
         <Grid container>
           <Grid item xs={4}>
             <h3>Fee</h3>
-            <div>{fee}</div>
+            <div>{BigNumber(fee).toFixed(8)} BTC </div>
           </Grid>
           <Grid item xs={4}>
             <h3>Fee Rate</h3>
-            <div>{feeRate}</div>
+            <div>{feeRate} sats/byte</div>
           </Grid>
           <Grid item xs={4}>
             <h3>Total</h3>
             <div>
-              {satoshisToBitcoins(BigNumber(inputsTotalSats || 0)).toString()}
+              {satoshisToBitcoins(BigNumber(inputsTotalSats || 0)).toFixed(8)}{" "}
+              BTC
             </div>
           </Grid>
         </Grid>

--- a/src/reducers/braidReducer.js
+++ b/src/reducers/braidReducer.js
@@ -1,7 +1,6 @@
 import BigNumber from "bignumber.js";
 import {
   RESET_NODES_SPEND,
-  SPEND_SLICES,
   RESET_NODES_FETCH_ERRORS,
 } from "../actions/walletActions";
 import updateState from "./utils";
@@ -60,7 +59,6 @@ function updateSlice(state, action) {
       },
     },
   };
-
   if (typeof action.value.spend !== "undefined") {
     // TODO (BUCK): I'm not sure this works. If you change
     // the output value of a spend before spending, this will just
@@ -113,21 +111,6 @@ function updateSlice(state, action) {
   return updatedState;
 }
 
-function spendSlices(state) {
-  const updatedState = { ...state };
-  Object.values(updatedState.nodes).forEach((node) => {
-    if (node.spend) {
-      updatedState.balanceSats = updatedState.balanceSats.minus(
-        node.balanceSats
-      );
-      node.balanceSats = new BigNumber(0); // eslint-disable-line no-param-reassign
-      node.spend = false; // eslint-disable-line no-param-reassign
-      node.utxos = []; // eslint-disable-line no-param-reassign
-    }
-  });
-  return updatedState;
-}
-
 function resetSpend(state) {
   const updatedState = { ...state };
   Object.values(updatedState.nodes).forEach((node) => {
@@ -140,8 +123,6 @@ export default (actionType) => (state = initialState, action) => {
   switch (action.type) {
     case RESET_NODES_SPEND:
       return resetSpend(state);
-    case SPEND_SLICES:
-      return spendSlices(state);
     case RESET_NODES_FETCH_ERRORS:
       return updateState(state, {
         fetchUTXOsErrors: 0,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes a bug where slice updates for inputs and outputs (most importantly the change) weren't being queried or updated properly after a spend resulting in incorrect wallet balances requiring a refresh to show properly. 

The issue was the state was being updated during other action calls that didn't need to be made anymore. Specifically a change output was assumed and updated manually without waiting for a response which bumped the "nextNode" for change, confusing the state for when they were being checked against a bitcoin client. The code causing this was cleaned up as well as using some recursion in the event that the call didn't return any updates to check again (checking a total of 5 times). 

<!---
  Please describe your change(s) in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

## Does this PR introduce a breaking change?

<!--
  If this PR contains a breaking change,
  please also describe the impact and migration path for existing applications
-->

* [ ] Yes
* [x] No

## Does this PR fixes open issues?
Fixes: #104 
<!-- If this PR contain fixes to open issues please link them here -->

* [x] Yes
* [ ] No
