### PR TITLE
Make client and method optional in wallet config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,4 +133,4 @@ point caravan at 'http://localhost:1337/localhost:8332'.
 
 ## Contributing
 
-Please see the [`CONTRIBUTING.md`](./CONTRIBUTING.md) and the open [GitHub Issues](https://github.com/caravan/issues).
+Please see the [`CONTRIBUTING.md`](./CONTRIBUTING.md) and the open [GitHub Issues](https://github.com/caravan/issues)

--- a/src/components/ClientPicker/index.jsx
+++ b/src/components/ClientPicker/index.jsx
@@ -140,7 +140,7 @@ class ClientPicker extends React.Component {
                   checked={client.type === "private"}
                 />
               </RadioGroup>
-              {client.type === "public" ? (
+              {client.type === "public" && (
                 <FormHelperText>
                   {"'Public' uses the "}
                   <code>blockstream.info</code>
@@ -148,7 +148,8 @@ class ClientPicker extends React.Component {
                   <code>bitcoind</code>
                   {" node."}
                 </FormHelperText>
-              ) : (
+              )}
+              {client.type === "private" && (
                 <PrivateClientSettings
                   handleUrlChange={(event) => this.handleUrlChange(event)}
                   handleUsernameChange={(event) =>

--- a/src/components/ScriptExplorer/SignatureImporter.jsx
+++ b/src/components/ScriptExplorer/SignatureImporter.jsx
@@ -42,6 +42,7 @@ import {
 import "react-table/react-table.css";
 
 const TEXT = "text";
+const UNKNOWN = "unknown";
 
 class SignatureImporter extends React.Component {
   titleRef = React.createRef();
@@ -106,7 +107,8 @@ class SignatureImporter extends React.Component {
       <form>
         {(extendedPublicKeyImporter === null ||
           typeof extendedPublicKeyImporter === "undefined" ||
-          extendedPublicKeyImporter.method === TEXT) && (
+          extendedPublicKeyImporter.method === TEXT ||
+          extendedPublicKeyImporter.method === UNKNOWN) && (
           <FormControl fullWidth>
             <InputLabel id={labelId}>Select Method</InputLabel>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Client and signing method may not be known by an external coordinator that can produce Caravan configs, these fields should be optional in the config, and gathering that information from the user should happen cleanly.

This PR adds that functionality.
During wallet config import, if client information is not included, the ClientPicker is displayed with no selection and the wallet cannot be initialized until a selection is made. This is to stop a user from accidentally using a public node if they would have preferred to use a private node.

If a signing method isn't included in the config, the method selector dialog is shown during signing (very similar to the 'enter as text' option), but the BIP32 path that was included in the config is used, unlike the 'enter as text' option.

Also, if a config file specifies `regtest` as the chain to use, it is converted to `testnet`. I haven't tested this, but I think to use regtest, a user would select 'testnet' and a private client, connecting to a local node running regtest.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

## Does this PR fixes open issues?

<!-- If this PR contain fixes to open issues please link them here -->

* [x] Yes
* [ ] No

#139 , kinda. I still don't think device type or client should be included in the config Caravan exports, but I didn't take them out at this time.