### PR TITLE
feat(wallet): starting Address Index loading, picking, exporting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2330,6 +2330,30 @@
         "@babel/runtime": "^7.4.4"
       }
     },
+    "@material-ui/lab": {
+      "version": "4.0.0-alpha.56",
+      "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.56.tgz",
+      "integrity": "sha512-xPlkK+z/6y/24ka4gVJgwPfoCF4RCh8dXb1BNE7MtF9bXEBLN/lBxNTK8VAa0qm3V2oinA6xtUIdcRh0aeRtVw==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/utils": "^4.10.2",
+        "clsx": "^1.0.4",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0"
+      },
+      "dependencies": {
+        "@material-ui/utils": {
+          "version": "4.10.2",
+          "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.10.2.tgz",
+          "integrity": "sha512-eg29v74P7W5r6a4tWWDAAfZldXIzfyO1am2fIsC39hdUUHm/33k6pGOKPbgDjg/U/4ifmgAePy/1OjkKN6rFRw==",
+          "requires": {
+            "@babel/runtime": "^7.4.4",
+            "prop-types": "^15.7.2",
+            "react-is": "^16.8.0"
+          }
+        }
+      }
+    },
     "@material-ui/pickers": {
       "version": "3.2.10",
       "resolved": "https://registry.npmjs.org/@material-ui/pickers/-/pickers-3.2.10.tgz",
@@ -18850,9 +18874,9 @@
       "integrity": "sha512-fqLNg8vpvLOD5J/z4B6wpPg4Lvowz1nJ9xdHcCzdUPKcFE/qNCceV2gNZxSJd5vhAZemHr/K/hbzVA0zxB5mkg=="
     },
     "unchained-bitcoin": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/unchained-bitcoin/-/unchained-bitcoin-0.0.13.tgz",
-      "integrity": "sha512-ADzQGX9CcaRfLiX0zjR8eYzVyVTAMBrZYe4r0GZwPQPN3WttRMvaWIbbDPfG/iidzPM444R1n/T+OBSWl61V7Q==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/unchained-bitcoin/-/unchained-bitcoin-0.0.14.tgz",
+      "integrity": "sha512-MHKIprbQs3rQnRs7v331t5Yge1CJGwt9gSi2WxiV94/ASz7mDjh36ia6qaWPKPmJI+YJnXYcI2UIe2A0DNCAeA==",
       "requires": {
         "@babel/polyfill": "^7.7.0",
         "bignumber.js": "^8.1.1",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "@ledgerhq/hw-transport-u2f": "^4.21.0",
     "@material-ui/core": "^4.9.11",
     "@material-ui/icons": "^4.5.1",
+    "@material-ui/lab": "^4.0.0-alpha.56",
     "axios": "^0.19.0",
     "base58check": "^2.0.0",
     "bignumber.js": "^9.0.0",
@@ -114,7 +115,7 @@
     "redux-promise": "^0.6.0",
     "redux-thunk": "^2.3.0",
     "reselect": "^4.0.0",
-    "unchained-bitcoin": "0.0.13",
+    "unchained-bitcoin": "0.0.14",
     "unchained-wallets": "0.1.1"
   }
 }

--- a/src/actions/settingsActions.js
+++ b/src/actions/settingsActions.js
@@ -1,6 +1,7 @@
 export const SET_NETWORK = "SET_NETWORK";
 export const SET_TOTAL_SIGNERS = "SET_TOTAL_SIGNERS";
 export const SET_REQUIRED_SIGNERS = "SET_REQUIRED_SIGNERS";
+export const SET_STARTING_ADDRESS_INDEX = "SET_STARTING_ADDRESS_INDEX";
 export const SET_ADDRESS_TYPE = "SET_ADDRESS_TYPE";
 export const SET_FROZEN = "SET_FROZEN";
 
@@ -21,6 +22,13 @@ export function setTotalSigners(number) {
 export function setRequiredSigners(number) {
   return {
     type: SET_REQUIRED_SIGNERS,
+    value: number,
+  };
+}
+
+export function setStartingAddressIndex(number) {
+  return {
+    type: SET_STARTING_ADDRESS_INDEX,
     value: number,
   };
 }

--- a/src/components/StartingAddressIndexPicker.jsx
+++ b/src/components/StartingAddressIndexPicker.jsx
@@ -1,0 +1,132 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { connect } from "react-redux";
+import { validateBIP32Index } from "unchained-bitcoin";
+import {
+  Grid,
+  Card,
+  CardHeader,
+  CardContent,
+  FormControlLabel,
+  FormControl,
+  FormHelperText,
+  Radio,
+  RadioGroup,
+  TextField,
+  Tooltip,
+} from "@material-ui/core";
+
+import { wrappedActions } from "../actions/utils";
+import { SET_STARTING_ADDRESS_INDEX } from "../actions/settingsActions";
+
+class StartingAddressIndexPicker extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      customIndex: props.startingAddressIndex !== 0,
+      startingAddressIndexField: props.startingAddressIndex,
+    };
+  }
+
+  handleIndexChange = (event) => {
+    const { setStartingAddressIndex } = this.props;
+    const index = event.target.value;
+    const error = validateBIP32Index(index, { mode: "unhardened" }).replace(
+      "BIP32",
+      "Starting Address"
+    );
+    if (!error && index) {
+      setStartingAddressIndex(parseInt(index, 10));
+    }
+    this.setState({
+      startingAddressIndexField: index,
+      startingAddressIndexError: error,
+    });
+  };
+
+  handleCustomIndexChange = (event) => {
+    const customIndex = event.target.value === "true";
+    this.setState({ customIndex });
+  };
+
+  render() {
+    const {
+      customIndex,
+      startingAddressIndexField,
+      startingAddressIndexError,
+    } = this.state;
+    return (
+      <Card>
+        <Grid container justify="space-between">
+          <CardHeader title="Starting Address Index" />
+        </Grid>
+        <CardContent>
+          <Grid item>
+            <FormControl component="fieldset">
+              <RadioGroup>
+                <FormControlLabel
+                  id="default"
+                  control={<Radio color="primary" />}
+                  name="customIndex"
+                  value="false"
+                  label={<strong>Default (0)</strong>}
+                  onChange={this.handleCustomIndexChange}
+                  checked={!customIndex}
+                />
+                <Tooltip
+                  title="The starting address index allows you to skip
+                    forward in a wallet. Addresses with indices less than the
+                    starting address are ignored."
+                >
+                  <FormControlLabel
+                    id="custom"
+                    control={<Radio color="primary" />}
+                    name="customIndex"
+                    value="true"
+                    label="Custom"
+                    onChange={this.handleCustomIndexChange}
+                    checked={customIndex}
+                  />
+                </Tooltip>
+                <FormHelperText>
+                  Use the default value if you do not understand how to use
+                  starting address index.
+                </FormHelperText>
+              </RadioGroup>
+              {customIndex && (
+                <TextField
+                  fullWidth
+                  value={startingAddressIndexField}
+                  type="text"
+                  name="startingAddressIndex"
+                  onChange={this.handleIndexChange}
+                  error={Boolean(startingAddressIndexError)}
+                  helperText={startingAddressIndexError}
+                />
+              )}
+            </FormControl>
+          </Grid>
+        </CardContent>
+      </Card>
+    );
+  }
+}
+
+StartingAddressIndexPicker.propTypes = {
+  startingAddressIndex: PropTypes.number.isRequired,
+  setStartingAddressIndex: PropTypes.func.isRequired,
+};
+
+function mapStateToProps(state) {
+  return {
+    startingAddressIndex: state.settings.startingAddressIndex,
+  };
+}
+
+export default connect(
+  mapStateToProps,
+  wrappedActions({
+    setStartingAddressIndex: SET_STARTING_ADDRESS_INDEX,
+  })
+)(StartingAddressIndexPicker);

--- a/src/components/Wallet/ConfirmWallet.jsx
+++ b/src/components/Wallet/ConfirmWallet.jsx
@@ -10,11 +10,18 @@ import {
   TableCell,
   Box,
 } from "@material-ui/core";
+import { Alert } from "@material-ui/lab";
 
 class WalletConfirmation extends React.Component {
   render = () => {
+    const { startingAddressIndex } = this.props;
     return (
       <Box>
+        {startingAddressIndex > 0 && (
+          <Alert severity="info">
+            Starting Address Index set to {startingAddressIndex}
+          </Alert>
+        )}
         <Table>
           <TableHead>
             <TableRow>
@@ -44,11 +51,13 @@ class WalletConfirmation extends React.Component {
 }
 
 WalletConfirmation.propTypes = {
+  startingAddressIndex: PropTypes.number.isRequired,
   extendedPublicKeyImporters: PropTypes.shape({}).isRequired,
 };
 
 function mapStateToProps(state) {
   return {
+    startingAddressIndex: state.settings.startingAddressIndex,
     extendedPublicKeyImporters: state.quorum.extendedPublicKeyImporters,
   };
 }

--- a/src/components/Wallet/WalletGenerator.jsx
+++ b/src/components/Wallet/WalletGenerator.jsx
@@ -161,13 +161,20 @@ class WalletGenerator extends React.Component {
   };
 
   generate = () => {
-    const { setImportersVisible, freeze, setGenerating } = this.props;
+    const {
+      setImportersVisible,
+      freeze,
+      setGenerating,
+      startingAddressIndex,
+    } = this.props;
+    const startingDepositBIP32Suffix = `m/0/${startingAddressIndex}`;
+    const startingChangeBIP32Suffix = `m/1/${startingAddressIndex}`;
     freeze(true);
     setImportersVisible(false);
     setGenerating(true);
     this.setState({ connectSuccess: false }, () => {
-      this.addNode(false, "m/0/0", true);
-      this.addNode(true, "m/1/0", true);
+      this.addNode(false, startingDepositBIP32Suffix, true);
+      this.addNode(true, startingChangeBIP32Suffix, true);
     });
   };
 
@@ -449,6 +456,7 @@ class WalletGenerator extends React.Component {
 WalletGenerator.propTypes = {
   network: PropTypes.string.isRequired,
   addressType: PropTypes.string.isRequired,
+  startingAddressIndex: PropTypes.number.isRequired,
   client: PropTypes.shape({
     password: PropTypes.string,
     passwordError: PropTypes.string,

--- a/src/components/Wallet/index.jsx
+++ b/src/components/Wallet/index.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import {
+  validateBIP32Index,
   validateBIP32Path,
   validateExtendedPublicKey,
   satoshisToBitcoins,
@@ -25,6 +26,7 @@ import NetworkPicker from "../NetworkPicker";
 import QuorumPicker from "../QuorumPicker";
 import AddressTypePicker from "../AddressTypePicker";
 import ClientPicker from "../ClientPicker";
+import StartingAddressIndexPicker from "../StartingAddressIndexPicker";
 import WalletGenerator from "./WalletGenerator";
 import ExtendedPublicKeyImporter from "./ExtendedPublicKeyImporter";
 import WalletActionsPanel from "./WalletActionsPanel";
@@ -40,6 +42,7 @@ import {
   setRequiredSigners as setRequiredSignersAction,
   setAddressType as setAddressTypeAction,
   setNetwork as setNetworkAction,
+  setStartingAddressIndex as setStartingAddressIndexAction,
 } from "../../actions/settingsActions";
 import {
   setExtendedPublicKeyImporterMethod as setExtendedPublicKeyImporterMethodAction,
@@ -86,6 +89,14 @@ class CreateWallet extends React.Component {
       ""
     );
     if (validProperties !== "") return validProperties;
+
+    if (config.startingAddressIndex !== undefined) {
+      const startingAddressIndexError = validateBIP32Index(
+        String(config.startingAddressIndex),
+        { mode: "unhardened " }
+      ).replace("BIP32", "Starting Address");
+      if (startingAddressIndexError !== "") return startingAddressIndexError;
+    }
 
     if (config.client) {
       const clientProperties =
@@ -218,6 +229,7 @@ class CreateWallet extends React.Component {
       setRequiredSigners,
       setAddressType,
       setNetwork,
+      setStartingAddressIndex,
       setExtendedPublicKeyImporterMethod,
       setExtendedPublicKeyImporterExtendedPublicKey,
       setExtendedPublicKeyImporterBIP32Path,
@@ -248,6 +260,10 @@ class CreateWallet extends React.Component {
       }
     } else {
       setClientType("unknown");
+    }
+    // optionally, set starting address index
+    if (walletConfiguration.startingAddressIndex) {
+      setStartingAddressIndex(walletConfiguration.startingAddressIndex);
     }
     walletConfiguration.extendedPublicKeys.forEach(
       (extendedPublicKey, index) => {
@@ -324,6 +340,9 @@ class CreateWallet extends React.Component {
           <Box mt={2}>
             <ClientPicker />
           </Box>
+          <Box mt={2}>
+            <StartingAddressIndexPicker />
+          </Box>
         </Grid>
       );
     return settings;
@@ -367,6 +386,7 @@ class CreateWallet extends React.Component {
       totalSigners,
       requiredSigners,
       walletName,
+      startingAddressIndex,
     } = this.props;
     return `{
   "name": "${walletName}",
@@ -379,9 +399,9 @@ class CreateWallet extends React.Component {
   },
   "extendedPublicKeys": [
 ${this.extendedPublicKeyImporterBIP32Paths()}
-  ]
-}
-`;
+  ],
+  "startingAddressIndex": ${startingAddressIndex}
+}`;
   };
 
   clientDetails = () => {
@@ -580,6 +600,7 @@ ${this.extendedPublicKeyImporterBIP32Paths()}
 
 CreateWallet.propTypes = {
   addressType: PropTypes.string.isRequired,
+  startingAddressIndex: PropTypes.number.isRequired,
   change: PropTypes.shape({
     balanceSats: PropTypes.shape({}),
     fetchUTXOsErrors: PropTypes.number,
@@ -609,6 +630,7 @@ CreateWallet.propTypes = {
   setAddressType: PropTypes.func.isRequired,
   setName: PropTypes.func.isRequired,
   setNetwork: PropTypes.func.isRequired,
+  setStartingAddressIndex: PropTypes.func.isRequired,
   setExtendedPublicKeyImporterMethod: PropTypes.func.isRequired,
   setExtendedPublicKeyImporterExtendedPublicKey: PropTypes.func.isRequired,
   setExtendedPublicKeyImporterBIP32Path: PropTypes.func.isRequired,
@@ -655,6 +677,7 @@ const mapDispatchToProps = {
   setRequiredSigners: setRequiredSignersAction,
   setAddressType: setAddressTypeAction,
   setNetwork: setNetworkAction,
+  setStartingAddressIndex: setStartingAddressIndexAction,
   setExtendedPublicKeyImporterMethod: setExtendedPublicKeyImporterMethodAction,
   setExtendedPublicKeyImporterExtendedPublicKey: setExtendedPublicKeyImporterExtendedPublicKeyAction,
   setExtendedPublicKeyImporterBIP32Path: setExtendedPublicKeyImporterBIP32PathAction,

--- a/src/reducers/settingsReducer.js
+++ b/src/reducers/settingsReducer.js
@@ -5,6 +5,7 @@ import {
   SET_NETWORK,
   SET_TOTAL_SIGNERS,
   SET_REQUIRED_SIGNERS,
+  SET_STARTING_ADDRESS_INDEX,
   SET_ADDRESS_TYPE,
   SET_FROZEN,
 } from "../actions/settingsActions";
@@ -14,6 +15,7 @@ const initialState = {
   totalSigners: 3,
   requiredSigners: 2,
   addressType: P2SH,
+  startingAddressIndex: 0,
   frozen: false,
 };
 
@@ -25,6 +27,8 @@ export default (state = initialState, action) => {
       return updateState(state, { totalSigners: action.value });
     case SET_REQUIRED_SIGNERS:
       return updateState(state, { requiredSigners: action.value });
+    case SET_STARTING_ADDRESS_INDEX:
+      return updateState(state, { startingAddressIndex: action.value });
     case SET_ADDRESS_TYPE:
       return updateState(state, { addressType: action.value });
     case SET_FROZEN:


### PR DESCRIPTION
## Description
Caravan is now aware of the starting address index. 
When loading a wallet config caravan will jump ahead to the starting address index.
When creating a new wallet, a new Starting Address Index Picker is available.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

## Does this PR fixes open issues?

* [x] Yes
* [ ] No
#149 
