### PR TITLE
chore(other): fix incorrectly generated changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,20 +4,11 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### [0.3.1](https://github.com/unchained-capital/caravan/compare/v0.2.1...v0.3.1) (2020-07-14)
 
-
-### ⚠ BREAKING CHANGES
-
-* **wallet:** None
-* **slices:** None
-
 ### Features
 
-* **wallet:** starting Address Index loading, picking, exporting ([653132a](https://github.com/unchained-capital/caravan/commit/653132aba3ac1fe19945b79c2f906ee311c9b8aa)), closes [#149](https://github.com/unchained-capital/caravan/issues/149)
+* **other:** update unchained-wallets to 0.1.3 ([6abefcc](https://github.com/unchained-capital/caravan/commit/6abefcc49c6c997b827079c0120ce2790c7aaadd))
 
 
-### Bug Fixes
-
-* **slices:** confirmAddress can handle unknown method ([fb31758](https://github.com/unchained-capital/caravan/commit/fb31758033df16c2d3545bfc95dd8f7267e416c4))
 
 ## [0.3.0](https://github.com/unchained-capital/caravan/compare/v0.2.1...v0.3.0) (2020-07-09)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The changelog was generated incorrectly in 3.0 because of rebasing
to include the summary.  In order to fix I had to allow the
standard-version tool to add the changelog from 3.0 again.  This
commit removes the duplicate 3.0 changes and adds a note about
updating unchained-wallets.
<!---
  Please describe your change(s) in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

## Does this PR introduce a breaking change?

<!--
  If this PR contains a breaking change,
  please also describe the impact and migration path for existing applications
-->

* [ ] Yes
* [x] No

## Does this PR fixes open issues?

<!-- If this PR contain fixes to open issues please link them here -->

* [ ] Yes
* [x] No
