### PR TITLE
build(other): make commitlint check latest commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "gh-pages": "CI=true npm run build && gh-pages -d build",
     "lint": "npm run lint:code && npm run lint:commit",
     "lint:code": "eslint --ext .js,.jsx src/",
-    "lint:commit": "commitlint -e",
+    "lint:commit": "commitlint --from=HEAD~1",
     "lint:commit-travis": "commitlint-travis",
     "predeploy": "npm run build",
     "release": "standard-version",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Instead of using commitlint -e which checks the last commit from
.git/COMMIT_EDITMSG use --from which checks actual changelog
history.
<!---
  Please describe your change(s) in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

## Does this PR introduce a breaking change?

<!--
  If this PR contains a breaking change,
  please also describe the impact and migration path for existing applications
-->

* [ ] Yes
* [x] No

## Does this PR fix an open issue?

<!-- If this PR contain fixes to open issues please link them here -->

* [ ] Yes
* [x] No
