### PR TITLE
fix(slices): use unixtime to compare lastUsed dates

### DIFF
--- a/src/selectors/wallet.js
+++ b/src/selectors/wallet.js
@@ -78,6 +78,7 @@ export const getSlicesWithLastUsed = createSelector(
       return {
         ...slice,
         lastUsed: new Date(1000 * maxtime).toLocaleDateString(),
+        lastUsedTime: maxtime,
       };
     });
   }

--- a/src/utils/slices.js
+++ b/src/utils/slices.js
@@ -72,17 +72,17 @@ export function compareSlicesByTime(a, b, orderDir = "asc") {
   if (b.lastUsed === "Spent")
     return a.lastUsed && a.lastUsed !== "Spent" ? direction : -direction;
 
-  // if there is a last used param then we should be able to compare those
-  if (a.lastUsed && b.lastUsed) {
-    if (a.lastUsed === b.lastUsed) return 0;
-    return a.lastUsed >= b.lastUsed ? direction : -direction;
+  // if there is a lastUsedTime param then we should be able to compare those
+  if (a.lastUsedTime && b.lastUsedTime) {
+    if (a.lastUsedTime === b.lastUsedTime) return 0;
+    return a.lastUsedTime >= b.lastUsedTime ? direction : -direction;
   }
 
-  if (a.lastUsed && (!b.lastUsed || b.utxos.length === 0)) {
+  if (a.lastUsedTime && (!b.lastUsedTime || b.utxos.length === 0)) {
     return direction;
   }
 
-  if (b.lastUsed && (!a.lastUsed || a.utxos.length === 0)) {
+  if (b.lastUsedTime && (!a.lastUsedTime || a.utxos.length === 0)) {
     return -direction;
   }
 
@@ -92,13 +92,13 @@ export function compareSlicesByTime(a, b, orderDir = "asc") {
   if (b.utxos.length === 0) {
     return a.utxos.length === 0 ? 0 : -direction;
   }
-  const amin = Math.min(...a.utxos.map((utxo) => utxo.time));
-  const bmin = Math.min(...b.utxos.map((utxo) => utxo.time));
+  const amax = Math.max(...a.utxos.map((utxo) => utxo.time));
+  const bmax = Math.max(...b.utxos.map((utxo) => utxo.time));
 
-  if (Number.isNaN(amin) && Number.Number.isNaN(bmin)) return 0;
-  if (Number.isNaN(amin)) return direction;
-  if (Number.isNaN(bmin)) return -direction;
-  return amin > bmin ? direction : -direction;
+  if (Number.isNaN(amax) && Number.Number.isNaN(bmax)) return 0;
+  if (Number.isNaN(amax)) return direction;
+  if (Number.isNaN(bmax)) return -direction;
+  return amax > bmax ? direction : -direction;
 }
 
 export function isChange(path) {

--- a/src/utils/slices.test.js
+++ b/src/utils/slices.test.js
@@ -16,6 +16,7 @@ describe("slices utils", () => {
       a = {
         bip32Path: "m/0/5",
         lastUsed: "04/20/2020",
+        lastUsedTime: 1587458800000,
         utxos: [
           {
             time: 1587358800000,
@@ -28,6 +29,7 @@ describe("slices utils", () => {
       b = {
         bip32Path: "m/0/6",
         lastUsed: "04/23/2020",
+        lastUsedTime: 1587758800000,
         utxos: [
           {
             time: 1587458800000,
@@ -50,27 +52,35 @@ describe("slices utils", () => {
 
       // b is before a
       a.lastUsed = "04/23/2020";
+      a.lastUsedTime = 1587758800000;
       b.lastUsed = "04/20/2020";
+      b.lastUsedTime = 1587458800000;
       expect(sliceUtils.compareSlicesByTime(a, b)).toEqual(-1);
 
       // a and b are at the same time
       b.lastUsed = a.lastUsed;
+      b.lastUsedTime = a.lastUsedTime;
       expect(sliceUtils.compareSlicesByTime(a, b)).toEqual(0);
 
       // b is undefined
       b.lastUsed = undefined;
+      b.lastUsedTime = undefined;
       expect(sliceUtils.compareSlicesByTime(a, b)).toEqual(-1);
 
       // a is undefined
       b.lastUsed = a.lastUsed;
+      b.lastUsedTime = a.lastUsedTime;
       a.lastUsed = undefined;
+      a.lastUsedTime = undefined;
       expect(sliceUtils.compareSlicesByTime(a, b)).toEqual(1);
     });
 
     it("should correctly compare by utxo list", () => {
       // lastUsed is checked first so need to reset to get to utxo checks
       a.lastUsed = undefined;
+      a.lastUsedTime = undefined;
       b.lastUsed = undefined;
+      b.lastUsedTime = undefined;
 
       expect(sliceUtils.compareSlicesByTime(a, b)).toEqual(1);
       expect(sliceUtils.compareSlicesByTime(a, b, desc)).toEqual(-1);


### PR DESCRIPTION
## Description

Before this change, sorting adresses by Last used date didn't work correctly in countries where default date format is e.g. DD.MM.YYYY (1.3.2020 was displayed before 7.11.2019 and that was shown before 9.3.2020). This pull request fixes this problem by comparing last used dates as unixtimes and not as localized strings (returned by toLocaleDateString() method).

Furthermore, previously when lastUsed property wasn't initialized for individual addresses, corresponding value (that was later used for comparison) was calculated as minimum of times of individual utxos - which would be the time when the adress was used for the first time and not for the last time. 

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

## Does this PR fix an open issue?

* [ ] Yes
* [x] No