### PR TITLE
build(other): add gh action for deploying release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,24 @@
+name: Build and Deploy
+on: [release]
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.1
+        with:
+          persist-credentials: false
+
+      - name: Install and Build
+        run: |
+          sudo apt-get install libudev-dev libusb-1.0-0-dev
+          npm install
+          npm run build
+
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@3.7.1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: build
+          CLEAN: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,13 +69,15 @@ git push origin my-branch
 
 ## Releasing Caravan
 
-Caravan is released to Unchained Capital's GitHub Pages (https://unchained-capital.github.io/) by using the following:
+Caravan is released to GitHub Pages (https://unchained-capital.github.io/) by using the following:
 
 ```sh
 npm run release
 git push --follow-tags origin master
-npm run gh-pages
 ```
+
+Then go to GitHub and create a release in the UI.  This will trigger a build and deployment to GitHub pages.
+
 
 ## Help needed
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Use a github action to deploy the build to github pages after a
release is created.

## Does this PR introduce a breaking change?

<!--
  If this PR contains a breaking change,
  please also describe the impact and migration path for existing applications
-->

* [ ] Yes
* [x] No

## Does this PR fix an open issue?

<!-- If this PR contain fixes to open issues please link them here -->

* [ ] Yes
* [x] No
