### PR TITLE
fix(wallet): direct Edit Details btn to editable pubkey page

### DIFF
--- a/src/components/Wallet/WalletGenerator.jsx
+++ b/src/components/Wallet/WalletGenerator.jsx
@@ -143,18 +143,20 @@ class WalletGenerator extends React.Component {
     ).length;
   };
 
-  toggleImporters = (event) => {
+  toggleImporters = (event, type) => {
     event.preventDefault();
     const {
       setImportersVisible,
       configuring,
       resetWallet,
+      initialLoadComplete,
       setGenerating,
     } = this.props;
 
     if (!configuring) {
       setGenerating(false);
-      resetWallet();
+      if (type === "edit") initialLoadComplete();
+      if (type === "clear") resetWallet();
     }
 
     setImportersVisible(!configuring);
@@ -370,7 +372,7 @@ class WalletGenerator extends React.Component {
           <Card>
             <CardHeader title={this.title()} />
             <CardContent>
-              <Button href="#" onClick={this.toggleImporters}>
+              <Button href="#" onClick={(e) => this.toggleImporters(e, "edit")}>
                 {configuring ? "Hide Key Selection" : "Edit Details"}
               </Button>
               <ConfirmWallet />
@@ -380,7 +382,7 @@ class WalletGenerator extends React.Component {
                 information.
               </p>
               <WalletConfigInteractionButtons
-                onClearFn={(e) => this.toggleImporters(e)}
+                onClearFn={(e) => this.toggleImporters(e, "clear")}
                 onDownloadFn={downloadWalletDetails}
               />
               {unknownClient && (

--- a/src/components/Wallet/WalletGenerator.jsx
+++ b/src/components/Wallet/WalletGenerator.jsx
@@ -143,7 +143,7 @@ class WalletGenerator extends React.Component {
     ).length;
   };
 
-  toggleImporters = (event, type) => {
+  toggleImporters = (event, clear) => {
     event.preventDefault();
     const {
       setImportersVisible,
@@ -155,8 +155,8 @@ class WalletGenerator extends React.Component {
 
     if (!configuring) {
       setGenerating(false);
-      if (type === "edit") initialLoadComplete();
-      if (type === "clear") resetWallet();
+      if (clear) resetWallet();
+      if (!clear) initialLoadComplete();
     }
 
     setImportersVisible(!configuring);
@@ -372,7 +372,7 @@ class WalletGenerator extends React.Component {
           <Card>
             <CardHeader title={this.title()} />
             <CardContent>
-              <Button href="#" onClick={(e) => this.toggleImporters(e, "edit")}>
+              <Button href="#" onClick={(e) => this.toggleImporters(e, false)}>
                 {configuring ? "Hide Key Selection" : "Edit Details"}
               </Button>
               <ConfirmWallet />
@@ -382,7 +382,7 @@ class WalletGenerator extends React.Component {
                 information.
               </p>
               <WalletConfigInteractionButtons
-                onClearFn={(e) => this.toggleImporters(e, "clear")}
+                onClearFn={(e) => this.toggleImporters(e, true)}
                 onDownloadFn={downloadWalletDetails}
               />
               {unknownClient && (


### PR DESCRIPTION
ISSUES: #109

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!---
  Please describe your change(s) in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

Bug fix for an open issue (#109) where the Edit Details button would clear the wallet when clicked. It now directs back to the editable xpubs page.

![caravan-pr](https://user-images.githubusercontent.com/44484504/102762829-2e062780-43bc-11eb-90ad-b44a1195c51a.gif)

## Does this PR introduce a breaking change?

<!--
  If this PR contains a breaking change,
  please also describe the impact and migration path for existing applications
-->

* [ ] Yes
* [X] No

## Does this PR fix an open issue?

<!-- If this PR contain fixes to open issues please link them here -->

* [X] Yes
* [ ] No
#109 