### PR TITLE
fix(pubkeyimporter): jS error when using Enter as text with incorrect access type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23352,9 +23352,9 @@
       "optional": true
     },
     "unchained-bitcoin": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/unchained-bitcoin/-/unchained-bitcoin-0.1.2.tgz",
-      "integrity": "sha512-N2LW+qPgK4hGoYi0wqBFH900N1Ysw1K+MUsqiN3JY0eVe/6HiwiXV+1LyIQzpzmgSPHxOPskJT7O/7oBxaly6A==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/unchained-bitcoin/-/unchained-bitcoin-0.1.3.tgz",
+      "integrity": "sha512-6y/ieRdx330391Gk5rlYh28xsU7abUCsa77FtbT/3hlGBHGdBi1Y4n/Vp2eRAyAYrV6seZvds7Asi98q7EMo5A==",
       "requires": {
         "@babel/polyfill": "^7.7.0",
         "bignumber.js": "^8.1.1",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "redux-promise": "^0.6.0",
     "redux-thunk": "^2.3.0",
     "reselect": "^4.0.0",
-    "unchained-bitcoin": "^0.1.2",
+    "unchained-bitcoin": "^0.1.3",
     "unchained-wallets": "^0.1.15"
   }
 }

--- a/src/components/CreateAddress/AddressGenerator.jsx
+++ b/src/components/CreateAddress/AddressGenerator.jsx
@@ -6,6 +6,7 @@ import {
   scriptToHex,
   multisigRedeemScript,
   multisigWitnessScript,
+  validatePublicKey,
 } from "unchained-bitcoin";
 import {
   Box,
@@ -16,11 +17,7 @@ import {
   CardContent,
   FormHelperText,
 } from "@material-ui/core";
-import {
-  externalLink,
-  downloadFile,
-  uncompressedPublicKeyError,
-} from "../../utils";
+import { externalLink, downloadFile } from "../../utils";
 
 // Actions
 import {
@@ -43,10 +40,11 @@ class AddressGenerator extends React.Component {
   publicKeyCount = () => {
     const { publicKeyImporters, addressType } = this.props;
     return Object.values(publicKeyImporters).filter((publicKeyImporter) => {
-      return (
-        publicKeyImporter.finalized &&
-        !uncompressedPublicKeyError(publicKeyImporter.publicKey, addressType)
+      const publicKeyError = validatePublicKey(
+        publicKeyImporter.publicKey,
+        addressType
       );
+      return publicKeyImporter.finalized && !publicKeyError;
     }).length;
   };
 

--- a/src/components/CreateAddress/AddressGenerator.jsx
+++ b/src/components/CreateAddress/AddressGenerator.jsx
@@ -16,7 +16,11 @@ import {
   CardContent,
   FormHelperText,
 } from "@material-ui/core";
-import { externalLink, downloadFile } from "../../utils";
+import {
+  externalLink,
+  downloadFile,
+  uncompressedPublicKeyError,
+} from "../../utils";
 
 // Actions
 import {
@@ -37,10 +41,13 @@ class AddressGenerator extends React.Component {
   };
 
   publicKeyCount = () => {
-    const { publicKeyImporters } = this.props;
-    return Object.values(publicKeyImporters).filter(
-      (publicKeyImporter) => publicKeyImporter.finalized
-    ).length;
+    const { publicKeyImporters, addressType } = this.props;
+    return Object.values(publicKeyImporters).filter((publicKeyImporter) => {
+      return (
+        publicKeyImporter.finalized &&
+        !uncompressedPublicKeyError(publicKeyImporter.publicKey, addressType)
+      );
+    }).length;
   };
 
   publicKeysAreCanonicallySorted = () => {

--- a/src/components/CreateAddress/AddressGenerator.jsx
+++ b/src/components/CreateAddress/AddressGenerator.jsx
@@ -39,13 +39,11 @@ class AddressGenerator extends React.Component {
 
   publicKeyCount = () => {
     const { publicKeyImporters, addressType } = this.props;
-    return Object.values(publicKeyImporters).filter((publicKeyImporter) => {
-      const publicKeyError = validatePublicKey(
-        publicKeyImporter.publicKey,
-        addressType
-      );
-      return publicKeyImporter.finalized && !publicKeyError;
-    }).length;
+    return Object.values(publicKeyImporters).filter(
+      ({ publicKey, finalized }) => {
+        return finalized && !validatePublicKey(publicKey, addressType);
+      }
+    ).length;
   };
 
   publicKeysAreCanonicallySorted = () => {

--- a/src/components/CreateAddress/PublicKeyImporter.jsx
+++ b/src/components/CreateAddress/PublicKeyImporter.jsx
@@ -53,14 +53,11 @@ class PublicKeyImporter extends React.Component {
 
   componentDidUpdate(prevProps) {
     const { number, setFinalized, addressType, publicKeyImporter } = this.props;
-    if (prevProps.addressType !== addressType) {
-      const publicKeyError = validatePublicKey(
-        publicKeyImporter.publicKey,
-        addressType
-      );
-      if (publicKeyError) {
-        setFinalized(number, false);
-      }
+    if (
+      prevProps.addressType !== addressType &&
+      validatePublicKey(publicKeyImporter.publicKey, addressType)
+    ) {
+      setFinalized(number, false);
     }
   }
 
@@ -337,6 +334,10 @@ class PublicKeyImporter extends React.Component {
 
   render() {
     const { publicKeyImporter, addressType } = this.props;
+    const publicKeyError = validatePublicKey(
+      publicKeyImporter.publicKey,
+      addressType
+    );
     return (
       <Card>
         <CardHeader title={this.title()} />
@@ -346,16 +347,9 @@ class PublicKeyImporter extends React.Component {
             publicKeyImporter.conflict && (
               <Conflict message="Warning, BIP32 path is in conflict with the network and address type settings.  Do not proceed unless you are absolutely sure you know what you are doing!" />
             )}
-          {validatePublicKey(publicKeyImporter.publicKey, addressType).includes(
+          {publicKeyError.includes(
             "does not support uncompressed public keys"
-          ) && (
-            <Conflict
-              message={validatePublicKey(
-                publicKeyImporter.publicKey,
-                addressType
-              )}
-            />
-          )}
+          ) && <Conflict message={publicKeyError} />}
           {publicKeyImporter.finalized
             ? this.renderPublicKey()
             : this.renderImport()}

--- a/src/components/CreateAddress/TextPublicKeyImporter.jsx
+++ b/src/components/CreateAddress/TextPublicKeyImporter.jsx
@@ -61,7 +61,8 @@ class TextPublicKeyImporter extends React.Component {
 
   handleChange = (event) => {
     const publicKey = event.target.value;
-    const error = validatePublicKey(publicKey);
+    const { addressType } = this.props;
+    const error = validatePublicKey(publicKey, addressType);
     this.setState({ publicKey, error });
   };
 }
@@ -69,6 +70,7 @@ class TextPublicKeyImporter extends React.Component {
 TextPublicKeyImporter.propTypes = {
   publicKeyImporter: PropTypes.shape({}).isRequired,
   validateAndSetPublicKey: PropTypes.func.isRequired,
+  addressType: PropTypes.string.isRequired,
 };
 
 export default TextPublicKeyImporter;

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,5 +1,6 @@
 import BigNumber from "bignumber.js";
 import { estimateMultisigTransactionFee } from "unchained-bitcoin/lib/fees";
+import { P2SH_P2WSH, P2WSH, validatePublicKey } from "unchained-bitcoin";
 
 import { DUST_IN_SATOSHIS } from "./constants";
 
@@ -179,4 +180,24 @@ export function naiveCoinSelection(options) {
     }
   }
   return [selectedUtxos, changeRequired];
+}
+
+/**
+ * @description A utility function that determines if a valid uncompressed
+ * public key (04...) is incompatible with a given address type
+ * @param {string} publicKey - compressed, uncompressed or invalid
+ * @param {string} addressType - one of P2SH, P2SH-P2WSH, P2WSH
+ * @returns {boolean} whether or not an uncompressed publicKey is incompatible
+ * for the given addressType
+ */
+export function uncompressedPublicKeyError(publicKey, addressType) {
+  const publicKeyError = validatePublicKey(publicKey);
+  if (
+    [P2SH_P2WSH, P2WSH].includes(addressType) &&
+    !publicKeyError &&
+    publicKey.substring(0, 2) === "04"
+  ) {
+    return true;
+  }
+  return false;
 }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,6 +1,5 @@
 import BigNumber from "bignumber.js";
 import { estimateMultisigTransactionFee } from "unchained-bitcoin/lib/fees";
-import { P2SH_P2WSH, P2WSH, validatePublicKey } from "unchained-bitcoin";
 
 import { DUST_IN_SATOSHIS } from "./constants";
 
@@ -180,24 +179,4 @@ export function naiveCoinSelection(options) {
     }
   }
   return [selectedUtxos, changeRequired];
-}
-
-/**
- * @description A utility function that determines if a valid uncompressed
- * public key (04...) is incompatible with a given address type
- * @param {string} publicKey - compressed, uncompressed or invalid
- * @param {string} addressType - one of P2SH, P2SH-P2WSH, P2WSH
- * @returns {boolean} whether or not an uncompressed publicKey is incompatible
- * for the given addressType
- */
-export function uncompressedPublicKeyError(publicKey, addressType) {
-  const publicKeyError = validatePublicKey(publicKey);
-  if (
-    [P2SH_P2WSH, P2WSH].includes(addressType) &&
-    !publicKeyError &&
-    publicKey.substring(0, 2) === "04"
-  ) {
-    return true;
-  }
-  return false;
 }

--- a/src/utils/utils.test.js
+++ b/src/utils/utils.test.js
@@ -3,11 +3,17 @@ import BigNumber from "bignumber.js";
 import {
   TEST_FIXTURES,
   estimateMultisigTransactionFee,
+  P2SH,
+  P2SH_P2WSH,
   P2WSH,
 } from "unchained-bitcoin";
 
 import { DUST_IN_SATOSHIS } from "./constants";
-import { isSpendAll, naiveCoinSelection } from "./index";
+import {
+  isSpendAll,
+  naiveCoinSelection,
+  uncompressedPublicKeyError,
+} from "./index";
 import { getMockState } from "./fixtures";
 import { getSpendableSlices } from "../selectors/wallet";
 
@@ -230,7 +236,7 @@ describe("utils", () => {
           .minus(fee)
           .minus(output.amountSats)
           .isGreaterThan(DUST_IN_SATOSHIS),
-        `Test slices balance amount minus fee and output 
+        `Test slices balance amount minus fee and output
  should be greater than dust so that change is required`
       );
 
@@ -250,6 +256,81 @@ describe("utils", () => {
       options.outputs = [output];
       const test = () => naiveCoinSelection(options);
       expect(test).toThrow();
+    });
+  });
+
+  describe("uncompressedPublicKeyError", () => {
+    const compressedPublicKey =
+      "0239b046b986903f1f4dc3c81e2e113718ad7e9ea9f4740a39fbc89974f65391bd";
+    const uncompressedPublicKey =
+      "04a17f3ad2ecde2fff2abd1b9ca77f35d5449a3b50a8b2dc9a0b5432d6596afd01ee884006f7e7191f430c7881626b95ae1bcacf9b54d7073519673edaea71ee53";
+    const invalidPublicKey =
+      "0139b046b986903f1f4dc3c81e2e113718ad7e9ea9f4740a39fbc89974f65391bd";
+    // P2SH
+    it("should correctly indentify that a compressed public used for P2SH has no error", () => {
+      assert.equal(
+        uncompressedPublicKeyError(compressedPublicKey, P2SH),
+        false,
+        `Should be false for a compressed public key and a ${P2SH} address type`
+      );
+    });
+    it("should correctly indentify that an uncompressed public used for P2SH has no error", () => {
+      assert.equal(
+        uncompressedPublicKeyError(uncompressedPublicKey, P2SH),
+        false,
+        `Should be false for an uncompressed public key and a ${P2SH} address type`
+      );
+    });
+    it("should correctly indentify that an invalid public used for P2SH has no error", () => {
+      assert.equal(
+        uncompressedPublicKeyError(invalidPublicKey, P2SH),
+        false,
+        `Should be false for a invalid public key and a ${P2SH} address type`
+      );
+    });
+    // P2SH-P2WSH
+    it("should correctly indentify that a compressed public used for P2SH-P2WSH has no error", () => {
+      assert.equal(
+        uncompressedPublicKeyError(compressedPublicKey, P2SH_P2WSH),
+        false,
+        `Should be false for a compressed public key and a ${P2SH_P2WSH} address type`
+      );
+    });
+    it("should correctly indentify that an compressed public used for P2SH-P2WSH is erroneous", () => {
+      assert.equal(
+        uncompressedPublicKeyError(uncompressedPublicKey, P2SH_P2WSH),
+        true,
+        `Should be false for a invalid public key and a ${P2SH_P2WSH} address type`
+      );
+    });
+    it("should correctly indentify that an invalid public used for P2SH-P2WSH has no error", () => {
+      assert.equal(
+        uncompressedPublicKeyError(invalidPublicKey, P2SH_P2WSH),
+        false,
+        `Should be false for a invalid public key and a ${P2SH_P2WSH} address type`
+      );
+    });
+    // P2WSH
+    it("should correctly indentify that a compressed public used for P2WSH has no error", () => {
+      assert.equal(
+        uncompressedPublicKeyError(compressedPublicKey, P2WSH),
+        false,
+        `Should be false for a compressed public key and a ${P2WSH} address type`
+      );
+    });
+    it("should correctly indentify that an compressed public used for P2WSH is erroneous", () => {
+      assert.equal(
+        uncompressedPublicKeyError(uncompressedPublicKey, P2WSH),
+        true,
+        `Should be false for a invalid public key and a ${P2WSH} address type`
+      );
+    });
+    it("should correctly indentify that an invalid public used for P2WSH has no error", () => {
+      assert.equal(
+        uncompressedPublicKeyError(invalidPublicKey, P2WSH),
+        false,
+        `Should be false for a invalid public key and a ${P2WSH} address type`
+      );
     });
   });
 });

--- a/src/utils/utils.test.js
+++ b/src/utils/utils.test.js
@@ -3,17 +3,11 @@ import BigNumber from "bignumber.js";
 import {
   TEST_FIXTURES,
   estimateMultisigTransactionFee,
-  P2SH,
-  P2SH_P2WSH,
   P2WSH,
 } from "unchained-bitcoin";
 
 import { DUST_IN_SATOSHIS } from "./constants";
-import {
-  isSpendAll,
-  naiveCoinSelection,
-  uncompressedPublicKeyError,
-} from "./index";
+import { isSpendAll, naiveCoinSelection } from "./index";
 import { getMockState } from "./fixtures";
 import { getSpendableSlices } from "../selectors/wallet";
 
@@ -256,81 +250,6 @@ describe("utils", () => {
       options.outputs = [output];
       const test = () => naiveCoinSelection(options);
       expect(test).toThrow();
-    });
-  });
-
-  describe("uncompressedPublicKeyError", () => {
-    const compressedPublicKey =
-      "0239b046b986903f1f4dc3c81e2e113718ad7e9ea9f4740a39fbc89974f65391bd";
-    const uncompressedPublicKey =
-      "04a17f3ad2ecde2fff2abd1b9ca77f35d5449a3b50a8b2dc9a0b5432d6596afd01ee884006f7e7191f430c7881626b95ae1bcacf9b54d7073519673edaea71ee53";
-    const invalidPublicKey =
-      "0139b046b986903f1f4dc3c81e2e113718ad7e9ea9f4740a39fbc89974f65391bd";
-    // P2SH
-    it("should correctly indentify that a compressed public used for P2SH has no error", () => {
-      assert.equal(
-        uncompressedPublicKeyError(compressedPublicKey, P2SH),
-        false,
-        `Should be false for a compressed public key and a ${P2SH} address type`
-      );
-    });
-    it("should correctly indentify that an uncompressed public used for P2SH has no error", () => {
-      assert.equal(
-        uncompressedPublicKeyError(uncompressedPublicKey, P2SH),
-        false,
-        `Should be false for an uncompressed public key and a ${P2SH} address type`
-      );
-    });
-    it("should correctly indentify that an invalid public used for P2SH has no error", () => {
-      assert.equal(
-        uncompressedPublicKeyError(invalidPublicKey, P2SH),
-        false,
-        `Should be false for a invalid public key and a ${P2SH} address type`
-      );
-    });
-    // P2SH-P2WSH
-    it("should correctly indentify that a compressed public used for P2SH-P2WSH has no error", () => {
-      assert.equal(
-        uncompressedPublicKeyError(compressedPublicKey, P2SH_P2WSH),
-        false,
-        `Should be false for a compressed public key and a ${P2SH_P2WSH} address type`
-      );
-    });
-    it("should correctly indentify that an compressed public used for P2SH-P2WSH is erroneous", () => {
-      assert.equal(
-        uncompressedPublicKeyError(uncompressedPublicKey, P2SH_P2WSH),
-        true,
-        `Should be false for a invalid public key and a ${P2SH_P2WSH} address type`
-      );
-    });
-    it("should correctly indentify that an invalid public used for P2SH-P2WSH has no error", () => {
-      assert.equal(
-        uncompressedPublicKeyError(invalidPublicKey, P2SH_P2WSH),
-        false,
-        `Should be false for a invalid public key and a ${P2SH_P2WSH} address type`
-      );
-    });
-    // P2WSH
-    it("should correctly indentify that a compressed public used for P2WSH has no error", () => {
-      assert.equal(
-        uncompressedPublicKeyError(compressedPublicKey, P2WSH),
-        false,
-        `Should be false for a compressed public key and a ${P2WSH} address type`
-      );
-    });
-    it("should correctly indentify that an compressed public used for P2WSH is erroneous", () => {
-      assert.equal(
-        uncompressedPublicKeyError(uncompressedPublicKey, P2WSH),
-        true,
-        `Should be false for a invalid public key and a ${P2WSH} address type`
-      );
-    });
-    it("should correctly indentify that an invalid public used for P2WSH has no error", () => {
-      assert.equal(
-        uncompressedPublicKeyError(invalidPublicKey, P2WSH),
-        false,
-        `Should be false for a invalid public key and a ${P2WSH} address type`
-      );
     });
   });
 });


### PR DESCRIPTION
Handling the error when an uncompressed public key is given to address types P2WSH or P2SH-P2WSH

ISSUES: https://github.com/unchained-capital/caravan/issues/164

Demo video:
https://user-images.githubusercontent.com/76526363/103631741-a97ee180-4f43-11eb-93dd-10a23ecdcb52.mp4

Thank for taking a look & sending feedbacks my way :)

