### PR TITLE
fix(other): replace corsproxy with nginx reverse proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ curl --user my_uname --data-binary \
 '{"jsonrpc": "1.0", "id":"curltest", "method": "getblockcount", "params": [] }' \
 -H 'content-type: text/plain;' http://127.0.0.1:8332
 # Test the nginx reverse proxy
-curl --user crabel --data-binary \
+curl --user my_uname --data-binary \
 '{"jsonrpc": "1.0", "id":"curltest", "method": "getblockcount", "params": [] }' \
 -H 'content-type: text/plain;' --resolve bitcoind.localhost:8080:127.0.0.1 http://bitcoind.localhost:8080
 ```

--- a/README.md
+++ b/README.md
@@ -210,8 +210,8 @@ sudo systemctl restart nginx
 On MacOS, starting the `nginx` daemon will prompt a popup window asking if you want `ngingx`
 to allow incoming network connections, which you will want to allow.
 
-Test the different ports where `my_name` is the user specified in the `bitcoin.conf` line
-`rpcauth=my_name:` (Don't use this username!):
+Test the different ports where `my_uname` is the user specified in the `bitcoin.conf` line
+`rpcauth=my_uname:` (Don't use this username!):
 
 ```bash
 # Test that bitcoin rpc is functioning correctly

--- a/bitcoind.proxy
+++ b/bitcoind.proxy
@@ -1,0 +1,79 @@
+upstream bitcoind {
+  # local server
+  server 127.0.0.1:8332;
+  # remote server
+  #server 192.168.0.22:18332
+}
+
+## mainnet configuration
+server {
+  listen 8080;
+  server_name bitcoind.localhost;
+
+  add_header 'Access-Control-Allow-Origin' '*' always;
+  add_header 'Access-Control-Allow-Methods' 'POST, OPTIONS';
+  # Custom headers and headers various browsers *should* be OK with but aren't
+  add_header 'Access-Control-Allow-Headers' 'Authorization,Accept,Origin,DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
+
+  location / {
+    if ($request_method = 'OPTIONS') {
+      # Tell client that this pre-flight info is valid for 20 days
+      add_header 'Access-Control-Max-Age' 1728000;
+      add_header 'Content-Type' 'text/plain; charset=utf-8';
+      add_header 'Content-Length' 0;
+      return 204;
+    }
+
+    if ($request_method = 'POST') {
+      add_header 'Access-Control-Allow-Credentials' 'true';
+      add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
+    }
+
+    proxy_pass http://bitcoind;
+    proxy_set_header Host $host;
+    proxy_set_header Accept-Encoding "";
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header Referer $http_referer;
+    proxy_set_header X-Forwarded-For "$http_x_forwarded_for, $realip_remote_addr";
+  }
+}
+
+## testnet configuration
+#upstream testnet {
+#  # local testnet 
+#  server 127.0.0.1:18332;
+#  # remote testnet
+#  #server 192.168.0.22:18332
+#}
+
+#server {
+#  listen 8080;
+#  server_name testnet.localhost;
+
+#  add_header 'Access-Control-Allow-Origin' '*' always;
+#  add_header 'Access-Control-Allow-Methods' 'POST, OPTIONS';
+#  # Custom headers and headers various browsers *should* be OK with but aren't
+#  add_header 'Access-Control-Allow-Headers' 'Authorization,Accept,Origin,DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
+
+#  location / {
+#    if ($request_method = 'OPTIONS') {
+#      # Tell client that this pre-flight info is valid for 20 days
+#      add_header 'Access-Control-Max-Age' 1728000;
+#      add_header 'Content-Type' 'text/plain; charset=utf-8';
+#      add_header 'Content-Length' 0;
+#      return 204;
+#    }
+
+#    if ($request_method = 'POST') {
+#      add_header 'Access-Control-Allow-Credentials' 'true';
+#      add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
+#    }
+
+#    proxy_pass http://testnet;
+#    proxy_set_header Host $host;
+#    proxy_set_header Accept-Encoding "";
+#    proxy_set_header X-Real-IP $remote_addr;
+#    proxy_set_header Referer $http_referer;
+#    proxy_set_header X-Forwarded-For "$http_x_forwarded_for, $realip_remote_addr";
+#  }
+#}

--- a/bitcoind.proxy
+++ b/bitcoind.proxy
@@ -2,7 +2,7 @@ upstream bitcoind {
   # local server
   server 127.0.0.1:8332;
   # remote server
-  #server 192.168.0.22:18332
+  #server 192.168.0.22:8332
 }
 
 ## mainnet configuration
@@ -10,13 +10,12 @@ server {
   listen 8080;
   server_name bitcoind.localhost;
 
-  add_header 'Access-Control-Allow-Origin' '*' always;
-  add_header 'Access-Control-Allow-Methods' 'POST, OPTIONS';
-  # Custom headers and headers various browsers *should* be OK with but aren't
-  add_header 'Access-Control-Allow-Headers' 'Authorization,Accept,Origin,DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
-
   location / {
     if ($request_method = 'OPTIONS') {
+      add_header 'Access-Control-Allow-Origin' '*' always;
+      add_header 'Access-Control-Allow-Methods' 'POST, OPTIONS';
+      # Custom headers and headers various browsers *should* be OK with but aren't
+      add_header 'Access-Control-Allow-Headers' 'Authorization,Accept,Origin,DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
       # Tell client that this pre-flight info is valid for 20 days
       add_header 'Access-Control-Max-Age' 1728000;
       add_header 'Content-Type' 'text/plain; charset=utf-8';
@@ -25,6 +24,10 @@ server {
     }
 
     if ($request_method = 'POST') {
+      add_header 'Access-Control-Allow-Origin' '*' always;
+      add_header 'Access-Control-Allow-Methods' 'POST, OPTIONS';
+      # Custom headers and headers various browsers *should* be OK with but aren't
+      add_header 'Access-Control-Allow-Headers' 'Authorization,Accept,Origin,DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
       add_header 'Access-Control-Allow-Credentials' 'true';
       add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
     }
@@ -50,13 +53,12 @@ server {
 #  listen 8080;
 #  server_name testnet.localhost;
 
-#  add_header 'Access-Control-Allow-Origin' '*' always;
-#  add_header 'Access-Control-Allow-Methods' 'POST, OPTIONS';
-#  # Custom headers and headers various browsers *should* be OK with but aren't
-#  add_header 'Access-Control-Allow-Headers' 'Authorization,Accept,Origin,DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
-
 #  location / {
 #    if ($request_method = 'OPTIONS') {
+#      add_header 'Access-Control-Allow-Origin' '*' always;
+#      add_header 'Access-Control-Allow-Methods' 'POST, OPTIONS';
+#      # Custom headers and headers various browsers *should* be OK with but aren't
+#      add_header 'Access-Control-Allow-Headers' 'Authorization,Accept,Origin,DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
 #      # Tell client that this pre-flight info is valid for 20 days
 #      add_header 'Access-Control-Max-Age' 1728000;
 #      add_header 'Content-Type' 'text/plain; charset=utf-8';
@@ -65,6 +67,10 @@ server {
 #    }
 
 #    if ($request_method = 'POST') {
+#      add_header 'Access-Control-Allow-Origin' '*' always;
+#      add_header 'Access-Control-Allow-Methods' 'POST, OPTIONS';
+#      # Custom headers and headers various browsers *should* be OK with but aren't
+#      add_header 'Access-Control-Allow-Headers' 'Authorization,Accept,Origin,DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
 #      add_header 'Access-Control-Allow-Credentials' 'true';
 #      add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
 #    }


### PR DESCRIPTION
[`corsproxy`](https://www.npmjs.com/package/corsproxy) is no longer maintained and is failing build. CORS headers are not provided from [bitcoin-core](https://github.com/bitcoin/bitcoin/pull/12040) and so a supported alternative is needed. A reference configuration for the `nginx` reverse proxy is provided that adds the needed CORS header. CORS implementation instructions were revised to be consistent with the new method. 

ISSUES: 209

## Description

1. In the root `README.md`, `corsproxy` is no longer maintained on the npm website https://www.npmjs.com/package/corsproxy is listed as build failing, having been last updated 4-years ago.
2. All references for ` corsproxy` were removed from `README.md`
3. `README.md` was updated with implementation instructions for Debian and MacOS.
4. An `nginx` configuration file was provided that generates a reverse proxy to a bitcoin RPC server. The configuration provides the necessary CORS headers for integration with caravan.
5. Some minor edits in the command shell blocks of `README.md` were changed to be of type `bash` for proper formatting.

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No

## Does this PR fix an open issue?

<https://github.com/unchained-capital/caravan/issues/209>

* [X] Yes
* [ ] No
