### PR TITLE
fix(wallet): basic coin selection on spend

### DIFF
--- a/src/components/ScriptExplorer/OutputsForm.jsx
+++ b/src/components/ScriptExplorer/OutputsForm.jsx
@@ -64,10 +64,6 @@ class OutputsForm extends React.Component {
     this.scrollToTitle();
   };
 
-  componentDidUpdate = () => {
-    this.scrollToTitle();
-  };
-
   scrollToTitle = () => {
     const { signatureImporters, isWallet } = this.props;
     const finalizedCount = Object.keys(signatureImporters).reduce(

--- a/src/components/ScriptExplorer/UTXOSet.jsx
+++ b/src/components/ScriptExplorer/UTXOSet.jsx
@@ -86,7 +86,7 @@ class UTXOSet extends React.Component {
   };
 
   renderInputs = () => {
-    const { network, showSelection } = this.props;
+    const { network, showSelection, finalizedOutputs } = this.props;
     const { inputs } = this.state;
     return inputs.map((input, inputIndex) => {
       const confirmedStyle = `${styles.utxoTxid}${
@@ -102,6 +102,7 @@ class UTXOSet extends React.Component {
                 checked={input.checked}
                 onClick={() => this.toggleInput(inputIndex)}
                 color="primary"
+                disabled={finalizedOutputs}
               />
             </TableCell>
           )}
@@ -129,7 +130,12 @@ class UTXOSet extends React.Component {
   };
 
   render() {
-    const { inputs, inputsTotalSats, showSelection = true } = this.props;
+    const {
+      inputs,
+      inputsTotalSats,
+      showSelection = true,
+      finalizedOutputs,
+    } = this.props;
     const { inputsSatsSelected, toggleAll } = this.state;
     return (
       <>
@@ -147,6 +153,7 @@ class UTXOSet extends React.Component {
                     checked={toggleAll}
                     onClick={() => this.toggleAll()}
                     color="primary"
+                    disabled={finalizedOutputs}
                   />
                 </TableCell>
               )}
@@ -182,6 +189,7 @@ UTXOSet.propTypes = {
   multisig: PropTypes.oneOfType([PropTypes.shape({}), PropTypes.bool]),
   bip32Path: PropTypes.string,
   showSelection: PropTypes.bool,
+  finalizedOutputs: PropTypes.bool.isRequired,
 };
 
 UTXOSet.defaultProps = {
@@ -193,6 +201,7 @@ UTXOSet.defaultProps = {
 function mapStateToProps(state) {
   return {
     ...state.settings,
+    finalizedOutputs: state.spend.transaction.finalizedOutputs,
   };
 }
 

--- a/src/components/Slices/SliceDetails.jsx
+++ b/src/components/Slices/SliceDetails.jsx
@@ -105,7 +105,11 @@ const SliceDetails = ({ slice, client, network }) => {
         disabled: !slice.balanceSats.isGreaterThan(0),
       },
       panel: (
-        <UTXOSet inputs={slice.utxos} inputsTotalSats={slice.balanceSats} />
+        <UTXOSet
+          inputs={slice.utxos}
+          inputsTotalSats={slice.balanceSats}
+          showSelection={false}
+        />
       ),
     },
     {

--- a/src/components/Wallet/AddressExpander.jsx
+++ b/src/components/Wallet/AddressExpander.jsx
@@ -218,7 +218,7 @@ class AddressExpander extends React.Component {
 
   expandContent = () => {
     const { client, node } = this.props;
-    const { utxos, balanceSats, multisig } = node;
+    const { utxos, balanceSats, multisig, bip32Path } = node;
     const { expandMode } = this.state;
 
     if (client.type === "public" && expandMode === MODE_WATCH)
@@ -230,7 +230,12 @@ class AddressExpander extends React.Component {
       case MODE_UTXO:
         return (
           <Grid item md={12}>
-            <UTXOSet inputs={utxos} inputsTotalSats={balanceSats} />
+            <UTXOSet
+              inputs={utxos}
+              inputsTotalSats={balanceSats}
+              multisig={multisig}
+              bip32Path={bip32Path}
+            />
           </Grid>
         );
       case MODE_REDEEM:

--- a/src/components/Wallet/AddressExpander.jsx
+++ b/src/components/Wallet/AddressExpander.jsx
@@ -235,6 +235,7 @@ class AddressExpander extends React.Component {
               inputsTotalSats={balanceSats}
               multisig={multisig}
               bip32Path={bip32Path}
+              showSelection={false} // need a little more polish before we enable this
             />
           </Grid>
         );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Allow UTXO selection on spend. Works in both Redeem Script and Wallet interfaces but the Wallet interface is not 100% feature complete. E.g. if you try to spend a single utxo from multiple addresses that will not work properly right now. However, within a multi-address setup, you should be able to do coin selection.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

## Does this PR fix an open issue?

<!-- If this PR contain fixes to open issues please link them here -->

* [x] Yes
* [ ] No

Partially addresses https://github.com/unchained-capital/caravan/issues/54