### PR TITLE
fix(wallet): adds utxo selection to manual spend on wallet interface

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23438,15 +23438,15 @@
       }
     },
     "unchained-wallets": {
-      "version": "0.1.20",
-      "resolved": "https://registry.npmjs.org/unchained-wallets/-/unchained-wallets-0.1.20.tgz",
-      "integrity": "sha512-po2MgzA1quBaLzMv45q2c/sfShM0JKLaGPOpRzEQnVthyW5Skv5xrSvyHSw0yD7ali+WNg3C0dolQsTpgy3bUA==",
+      "version": "0.1.21",
+      "resolved": "https://registry.npmjs.org/unchained-wallets/-/unchained-wallets-0.1.21.tgz",
+      "integrity": "sha512-psRt5ATqu8ztguXZwdri5ub8rfdy4u+0bv9VdYdQNLPUWyvkaWp1g1XWR+iewNmEiLMVxcq8KsZLf67JwxZ6yg==",
       "requires": {
         "@babel/polyfill": "^7.7.0",
         "@ledgerhq/hw-app-btc": "^5.34.1",
         "@ledgerhq/hw-transport-node-hid": "^5.34.0",
         "@ledgerhq/hw-transport-u2f": "^5.34.0",
-        "@ledgerhq/hw-transport-webusb": "^5.51.3",
+        "@ledgerhq/hw-transport-webusb": "5.53.0",
         "bignumber.js": "^8.1.1",
         "bitcoinjs-lib": "^4.0.5",
         "bowser": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -120,6 +120,6 @@
     "redux-thunk": "^2.3.0",
     "reselect": "^4.0.0",
     "unchained-bitcoin": "^0.1.6",
-    "unchained-wallets": "^0.1.20"
+    "unchained-wallets": "^0.1.21"
   }
 }

--- a/src/components/ScriptExplorer/UTXOSet.jsx
+++ b/src/components/ScriptExplorer/UTXOSet.jsx
@@ -42,8 +42,7 @@ class UTXOSet extends React.Component {
     };
   }
 
-  // eslint-disable-next-line no-unused-vars
-  componentDidUpdate(prevProps, prevState, snapshot) {
+  componentDidUpdate(prevProps) {
     // This function exists because we need to respond to the parent node having
     // its select/spend checkbox clicked (toggling select-all or select-none).
     // None of this needs to happen on the redeem script interface.
@@ -157,10 +156,7 @@ class UTXOSet extends React.Component {
       const numLocalInputsToSpend = inputsToSpend.length;
       if (numLocalInputsToSpend === 0) {
         setSpendCheckbox(false);
-      } else if (
-        numLocalInputsToSpend >= 1 &&
-        numLocalInputsToSpend < localInputs.length
-      ) {
+      } else if (numLocalInputsToSpend < localInputs.length) {
         setSpendCheckbox("indeterminate");
       } else {
         setSpendCheckbox(true);

--- a/src/components/Wallet/AddressExpander.jsx
+++ b/src/components/Wallet/AddressExpander.jsx
@@ -217,8 +217,8 @@ class AddressExpander extends React.Component {
   };
 
   expandContent = () => {
-    const { client, node } = this.props;
-    const { utxos, balanceSats, multisig, bip32Path } = node;
+    const { client, node, setSpendCheckbox } = this.props;
+    const { utxos, balanceSats, multisig, bip32Path, spend } = node;
     const { expandMode } = this.state;
 
     if (client.type === "public" && expandMode === MODE_WATCH)
@@ -235,7 +235,10 @@ class AddressExpander extends React.Component {
               inputsTotalSats={balanceSats}
               multisig={multisig}
               bip32Path={bip32Path}
-              showSelection={false} // need a little more polish before we enable this
+              hideSelectAllInHeader
+              selectAll={spend}
+              node={node}
+              setSpendCheckbox={setSpendCheckbox}
             />
           </Grid>
         );
@@ -418,15 +421,18 @@ AddressExpander.propTypes = {
     multisig: PropTypes.shape({
       address: PropTypes.string,
     }),
+    spend: PropTypes.bool,
     utxos: PropTypes.arrayOf(PropTypes.shape({})),
   }).isRequired,
   network: PropTypes.string,
   requiredSigners: PropTypes.number.isRequired,
   totalSigners: PropTypes.number.isRequired,
+  setSpendCheckbox: PropTypes.func,
 };
 
 AddressExpander.defaultProps = {
   network: NETWORKS.TESTNET,
+  setSpendCheckbox: () => {},
 };
 
 function mapStateToProps(state) {
@@ -436,6 +442,7 @@ function mapStateToProps(state) {
     totalSigners: state.settings.totalSigners,
     client: state.client,
     extendedPublicKeyImporters: state.quorum.extendedPublicKeyImporters,
+    transaction: state.spend.transaction,
   };
 }
 

--- a/src/components/Wallet/Node.jsx
+++ b/src/components/Wallet/Node.jsx
@@ -53,7 +53,6 @@ class Node extends React.Component {
   render = () => {
     const {
       bip32Path,
-      spend,
       fetchedUTXOs,
       balanceSats,
       multisig,
@@ -71,7 +70,7 @@ class Node extends React.Component {
               id={bip32Path}
               name="spend"
               onChange={this.handleSpend}
-              checked={checked || spend}
+              checked={checked}
               disabled={!fetchedUTXOs || balanceSats.isEqualTo(0)}
               indeterminate={indeterminate}
             />

--- a/src/components/Wallet/Node.jsx
+++ b/src/components/Wallet/Node.jsx
@@ -53,6 +53,7 @@ class Node extends React.Component {
   render = () => {
     const {
       bip32Path,
+      spend,
       fetchedUTXOs,
       balanceSats,
       multisig,
@@ -70,7 +71,7 @@ class Node extends React.Component {
               id={bip32Path}
               name="spend"
               onChange={this.handleSpend}
-              checked={checked}
+              checked={checked || spend}
               disabled={!fetchedUTXOs || balanceSats.isEqualTo(0)}
               indeterminate={indeterminate}
             />

--- a/src/components/Wallet/Node.jsx
+++ b/src/components/Wallet/Node.jsx
@@ -40,8 +40,10 @@ class Node extends React.Component {
       this.markSpending(value);
     } else {
       // handles the case of de-selecting one-by-one until there's nothing left selected
+      // or there's only one utxo and we're selecting to spend it or not instead of at
+      // the top level select-all or deselect-all
       this.setState({ indeterminate: false, checked: value });
-      this.markSpending(false);
+      this.markSpending(value);
     }
   };
 

--- a/src/components/Wallet/Node.jsx
+++ b/src/components/Wallet/Node.jsx
@@ -16,14 +16,43 @@ import {
 import { WALLET_MODES } from "../../actions/walletActions";
 
 class Node extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      indeterminate: false,
+      checked: false,
+    };
+  }
+
   componentDidMount = () => {
     this.generate();
+  };
+
+  // Passing this fn down to the UTXOSet so we can get updates here, from there.
+  setSpendCheckbox = (value) => {
+    const { spend } = this.props;
+    if (value === "indeterminate") {
+      this.setState({ indeterminate: true, checked: false });
+      this.markSpending(true);
+    } else if (value === spend) {
+      // handles select/de-select all as well as have selected some and click select all
+      this.setState({ indeterminate: false, checked: value });
+      this.markSpending(value);
+    } else {
+      // handles the case of de-selecting one-by-one until there's nothing left selected
+      this.setState({ indeterminate: false, checked: value });
+      this.markSpending(false);
+    }
+  };
+
+  markSpending = (value) => {
+    const { change, bip32Path, updateNode } = this.props;
+    updateNode(change, { spend: value, bip32Path });
   };
 
   render = () => {
     const {
       bip32Path,
-      spend,
       fetchedUTXOs,
       balanceSats,
       multisig,
@@ -31,6 +60,7 @@ class Node extends React.Component {
       walletMode,
       addressKnown,
     } = this.props;
+    const { indeterminate, checked } = this.state;
     const spending = walletMode === WALLET_MODES.SPEND;
     return (
       <TableRow key={bip32Path}>
@@ -40,8 +70,9 @@ class Node extends React.Component {
               id={bip32Path}
               name="spend"
               onChange={this.handleSpend}
-              checked={spend}
+              checked={checked}
               disabled={!fetchedUTXOs || balanceSats.isEqualTo(0)}
+              indeterminate={indeterminate}
             />
           </TableCell>
         )}
@@ -71,7 +102,12 @@ class Node extends React.Component {
 
   renderAddress = () => {
     const { braidNode } = this.props;
-    return <AddressExpander node={braidNode} />;
+    return (
+      <AddressExpander
+        node={braidNode}
+        setSpendCheckbox={this.setSpendCheckbox}
+      />
+    );
   };
 
   generate = () => {
@@ -95,7 +131,21 @@ class Node extends React.Component {
       feeRate,
     } = this.props;
     let newInputs;
-    if (e.target.checked) {
+
+    if (e.target.getAttribute("data-indeterminate")) {
+      // remove any inputs that are ours
+      newInputs = inputs.filter((input) => {
+        const newUtxos = utxos.filter((utxo) => {
+          return utxo.txid === input.txid && utxo.index === input.index;
+        });
+        return newUtxos.length === 0;
+      });
+      // then add all ours back
+      newInputs = newInputs.concat(
+        utxos.map((utxo) => ({ ...utxo, multisig, bip32Path }))
+      );
+      this.setState({ indeterminate: false, checked: true });
+    } else if (e.target.checked) {
       newInputs = inputs.concat(
         utxos.map((utxo) => ({ ...utxo, multisig, bip32Path }))
       );

--- a/src/components/Wallet/NodeSet.jsx
+++ b/src/components/Wallet/NodeSet.jsx
@@ -27,7 +27,7 @@ class NodeSet extends React.Component {
     this.state = {
       page: 0,
       nodesPerPage: 10,
-      spend: false,
+      select: false,
       filterIncludeSpent: false,
       filterIncludeZeroBalance: false,
       orderBy: "bip32Path",
@@ -156,7 +156,7 @@ class NodeSet extends React.Component {
   };
 
   renderNodes = () => {
-    const { page, nodesPerPage, spend } = this.state;
+    const { page, nodesPerPage, select } = this.state;
     const { addNode, updateNode } = this.props;
     const startingIndex = page * nodesPerPage;
     const nodesRows = [];
@@ -173,7 +173,7 @@ class NodeSet extends React.Component {
           addNode={addNode}
           updateNode={updateNode}
           change={change}
-          spend={spend}
+          select={select}
         />
       );
       nodesRows.push(nodeRow);
@@ -209,7 +209,7 @@ class NodeSet extends React.Component {
         <Table style={{ tableLayout: "fixed" }}>
           <TableHead>
             <TableRow>
-              {spending && <TableCell width={62}>Spend?</TableCell>}
+              {spending && <TableCell width={62}>Select</TableCell>}
               <TableCell width={106}>
                 <TableSortLabel
                   active={orderBy === "bip32Path"}

--- a/src/components/Wallet/WalletSpend.jsx
+++ b/src/components/Wallet/WalletSpend.jsx
@@ -121,7 +121,6 @@ class WalletSpend extends React.Component {
   handleSpendMode = (event) => {
     const { updateAutoSpend, resetNodesSpend, deleteChangeOutput } = this.props;
     updateAutoSpend(!event.target.checked);
-    updateAutoSpend(!event.target.checked);
     resetNodesSpend();
     deleteChangeOutput();
   };

--- a/src/components/Wallet/WalletSpend.jsx
+++ b/src/components/Wallet/WalletSpend.jsx
@@ -102,7 +102,6 @@ class WalletSpend extends React.Component {
       finalizeOutputs,
       setSpendStep,
       resetNodesSpend,
-      autoSpend,
       deleteChangeOutput,
     } = this.props;
     setSpendStep(SPEND_STEP_CREATE);
@@ -112,10 +111,12 @@ class WalletSpend extends React.Component {
     // input nodes and change. So when going back to edit a transaction
     // we want to clear these from the state, since these are added automatically
     // when going from output form to transaction preview
-    if (autoSpend) {
-      resetNodesSpend();
-      deleteChangeOutput();
-    }
+
+    // for manual spend view, we don't store which utxo is selected right now
+    // So when going back to edit a transaction we want to clear everything
+    // from the state so that there are no surprises
+    resetNodesSpend();
+    deleteChangeOutput();
   };
 
   handleSpendMode = (event) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Allow UTXO selection on manual spend in Wallet interface.

<!---
  Please describe your change(s) in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

## Does this PR introduce a breaking change?

<!--
  If this PR contains a breaking change,
  please also describe the impact and migration path for existing applications
-->

* [ ] Yes
* [X] No

## Does this PR fix an open issue?

<!-- If this PR contain fixes to open issues please link them here -->

* [X] Yes
* [ ] No

Fixes #54 

Follow-up to https://github.com/unchained-capital/caravan/pull/221 - adds in the necessary logic to handle utxo selection across multiple addresses