### PR TITLE
Fix BIP 32 input in address generator 

### DIFF
--- a/src/components/CreateAddress/TextPublicKeyImporter.jsx
+++ b/src/components/CreateAddress/TextPublicKeyImporter.jsx
@@ -1,6 +1,5 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { validatePublicKey } from "unchained-bitcoin";
 
 // Components
 import { Button, TextField, Box } from "@material-ui/core";
@@ -45,9 +44,15 @@ class TextPublicKeyImporter extends React.Component {
   };
 
   import = () => {
-    const { validateAndSetPublicKey } = this.props;
+    const { validatePublicKey, onImport } = this.props;
     const { publicKey } = this.state;
-    validateAndSetPublicKey(publicKey, this.setError);
+    const error = validatePublicKey(publicKey);
+
+    if (error) {
+      this.setError(error);
+    } else {
+      onImport({ publicKey });
+    }
   };
 
   hasError = () => {
@@ -61,16 +66,15 @@ class TextPublicKeyImporter extends React.Component {
 
   handleChange = (event) => {
     const publicKey = event.target.value;
-    const { addressType } = this.props;
-    const error = validatePublicKey(publicKey, addressType);
+    const { validatePublicKey } = this.props;
+    const error = validatePublicKey(publicKey);
     this.setState({ publicKey, error });
   };
 }
 
 TextPublicKeyImporter.propTypes = {
-  publicKeyImporter: PropTypes.shape({}).isRequired,
-  validateAndSetPublicKey: PropTypes.func.isRequired,
-  addressType: PropTypes.string.isRequired,
+  validatePublicKey: PropTypes.func.isRequired,
+  onImport: PropTypes.func.isRequired,
 };
 
 export default TextPublicKeyImporter;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!---
  Please describe your change(s) in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

This is a partial fix to https://github.com/unchained-capital/caravan/issues/126 (partial because it doesn't address the scripts explorer page but only the addresses generator). 
The problem stated in the issue stems from the fact that the BIP 32 path and error are stored on different states (the path in redux, the error as part of the local state). My approach to fixing the issue involves moving the BIP 32 path to the local state so that it always changes at the same time as the error message. This has a couple of advantages:
* state and validation lives in a single place
* we hit the redux state only when the public key is valid (= better performance while editing in a single importer)

If you like the approach I'd be happy to open a similar PR for the scripts explorer page.

## Does this PR introduce a breaking change?

<!--
  If this PR contains a breaking change,
  please also describe the impact and migration path for existing applications
-->

* [ ] Yes
* [x] No

## Does this PR fix an open issue?

<!-- If this PR contain fixes to open issues please link them here -->

* [x] Yes, partially
* [ ] No

https://github.com/unchained-capital/caravan/issues/126