### PR TITLE
fix(other): fix currency formatting throughout app (#228)

### DIFF
--- a/src/components/ScriptExplorer/OutputEntry.jsx
+++ b/src/components/ScriptExplorer/OutputEntry.jsx
@@ -248,6 +248,11 @@ class OutputEntry extends React.Component {
             InputProps={{
               startAdornment: (
                 <InputAdornment position="start">
+                  <FormHelperText>BTC</FormHelperText>
+                </InputAdornment>
+              ),
+              endAdornment: (
+                <InputAdornment position="end">
                   {isWallet &&
                     autoSpend &&
                     number === outputs.length &&
@@ -260,11 +265,6 @@ class OutputEntry extends React.Component {
                         MAX
                       </Typography>
                     )}
-                </InputAdornment>
-              ),
-              endAdornment: (
-                <InputAdornment position="end">
-                  <FormHelperText>BTC</FormHelperText>
                 </InputAdornment>
               ),
             }}

--- a/src/components/ScriptExplorer/OutputsForm.jsx
+++ b/src/components/ScriptExplorer/OutputsForm.jsx
@@ -34,7 +34,7 @@ class OutputsForm extends React.Component {
   static unitLabel(label, options) {
     let inputProps = {
       endAdornment: (
-        <InputAdornment position="end">
+        <InputAdornment position="start">
           <FormHelperText>{label}</FormHelperText>
         </InputAdornment>
       ),

--- a/src/components/Wallet/TransactionPreview.jsx
+++ b/src/components/Wallet/TransactionPreview.jsx
@@ -172,7 +172,7 @@ class TransactionPreview extends React.Component {
         <Grid container>
           <Grid item xs={4}>
             <h3>Fee</h3>
-            <div>{BigNumber(fee).toFixed(8)} BTC </div>
+            <div>BTC {BigNumber(fee).toFixed(8)}</div>
           </Grid>
           <Grid item xs={4}>
             <h3>Fee Rate</h3>
@@ -181,8 +181,8 @@ class TransactionPreview extends React.Component {
           <Grid item xs={4}>
             <h3>Total</h3>
             <div>
-              {satoshisToBitcoins(BigNumber(inputsTotalSats || 0)).toFixed(8)}{" "}
-              BTC
+              BTC{" "}
+              {satoshisToBitcoins(BigNumber(inputsTotalSats || 0)).toFixed(8)}
             </div>
           </Grid>
         </Grid>

--- a/src/components/Wallet/WalletInfoCard.jsx
+++ b/src/components/Wallet/WalletInfoCard.jsx
@@ -69,7 +69,7 @@ const WalletInfoCard = ({
                     variant="subtitle1"
                     className={classes.balance}
                   >
-                    {balance} BTC
+                    BTC {balance}
                   </Typography>
                 </Grid>
                 <Grid item>
@@ -82,8 +82,8 @@ const WalletInfoCard = ({
                             fontWeight: "bold",
                           }}
                         >
-                          {pendingBalance > 0 ? "+" : ""}
-                          {pendingBalance} BTC
+                          BTC{" "}{pendingBalance > 0 ? "+" : ""}
+                          {pendingBalance}
                         </span>{" "}
                         (unconfirmed)
                       </>

--- a/src/components/Wallet/__tests__/WalletInfoCard.text.jsx
+++ b/src/components/Wallet/__tests__/WalletInfoCard.text.jsx
@@ -42,7 +42,7 @@ describe("WalletInfoCard", () => {
 
       expect(walletInfoCard).toBeVisible();
       expect(balance).toBeVisible();
-      expect(balance).toHaveTextContent("0 BTC");
+      expect(balance).toHaveTextContent("BTC 0");
       expect(bitcoinIcon).toHaveAttribute("color", "grey");
       expect(getByText(walletName)).toBeVisible();
       expect(pendingBalance).toBeEmpty();
@@ -53,7 +53,7 @@ describe("WalletInfoCard", () => {
       const { getByDataCy } = renderWalletInfoCard(props);
 
       const balance = getByDataCy("balance");
-      expect(balance).toHaveTextContent("10 BTC");
+      expect(balance).toHaveTextContent("BTC 10");
     });
 
     test("shows a pending balance", () => {
@@ -62,7 +62,7 @@ describe("WalletInfoCard", () => {
 
       const pendingBalance = getByDataCy("pending-balance");
       expect(pendingBalance).toHaveTextContent(
-        `+${props.pendingBalance} BTC (unconfirmed)`
+        `BTC +${props.pendingBalance} (unconfirmed)`
       );
     });
   });

--- a/src/tests/signing.jsx
+++ b/src/tests/signing.jsx
@@ -51,7 +51,7 @@ class SignMultisigTransactionTest extends Test {
             <TableRow>
               <TableCell>Output Amount:</TableCell>
               <TableCell>
-                {satoshisToBitcoins(this.outputAmountSats()).toString()} BTC
+                BTC {satoshisToBitcoins(this.outputAmountSats()).toString()}
               </TableCell>
             </TableRow>
 
@@ -65,15 +65,15 @@ class SignMultisigTransactionTest extends Test {
             <TableRow>
               <TableCell>Change Output Amount:</TableCell>
               <TableCell>
-                {satoshisToBitcoins(this.changeOutputAmountSats()).toString()}{" "}
-                BTC
+                BTC{" "}
+                {satoshisToBitcoins(this.changeOutputAmountSats()).toString()}
               </TableCell>
             </TableRow>
 
             <TableRow>
               <TableCell>Fees:</TableCell>
               <TableCell>
-                {satoshisToBitcoins(this.feeSats()).toString()} BTC
+                BTC {satoshisToBitcoins(this.feeSats()).toString()}
               </TableCell>
             </TableRow>
           </TableBody>


### PR DESCRIPTION
Currencies in English should always have symbols and codes precede the
amount, not follow them, so this commit fixes all such instances
throughout the app.

## Description

The change fixes grammatical issues in the app.

Fixes #228 

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

## Does this PR fix an open issue?

* [x] Yes
* [ ] No
