### PR TITLE
build(other): fix release build gh action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,7 @@ jobs:
 
       - name: Install and Build
         run: |
+          sudo apt-get update
           sudo apt-get install libudev-dev libusb-1.0-0-dev
           npm install
           npm run build


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix the release gh action by running apt update before install.

Fixes [this](https://github.com/unchained-capital/caravan/runs/3187209224?check_suite_focus=true):

```
Err:1 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libudev-dev amd64 245.4-4ubuntu3.7
  404  Not Found [IP: 52.154.174.208 80]
Get:2 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libusb-1.0-0-dev amd64 2:1.0.23-2build1 [64.4 kB]
Get:3 http://azure.archive.ubuntu.com/ubuntu focal/main amd64 libusb-1.0-doc all 2:1.0.23-2build1 [172 kB]
Fetched 237 kB in 0s (2919 kB/s)
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/s/systemd/libudev-dev_245.4-4ubuntu3.7_amd64.deb  404  Not Found [IP: 52.154.174.208 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```



## Does this PR introduce a breaking change?

<!--
  If this PR contains a breaking change,
  please also describe the impact and migration path for existing applications
-->

* [ ] Yes
* [x] No

## Does this PR fix an open issue?

<!-- If this PR contain fixes to open issues please link them here -->

* [ ] Yes
* [x] No


