### PR TITLE
build(deps): disallow node 15 and above via engines and enginesStrict

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
     "url": "https://github.com/unchained-capital/caravan/issues"
   },
   "homepage": "https://unchained-capital.github.io/caravan",
+  "engineStrict": true,
+  "engines": {
+    "node": "<15"
+  },
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "^7.8.3",
     "@commitlint/cli": "^9.1.2",


### PR DESCRIPTION
Node 15+ are not supported by our current version of node-sass, 4 - the build fails when the two are
combined. By explicitly declaring that version as unsupported, we better communicate the issue.
https://www.npmjs.com/package/node-sass

Note 16 is the current "latest" release, 14 is the current "lts" release.
https://nodejs.org/en/

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!---
  Please describe your change(s) in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

## Does this PR introduce a breaking change?

<!--
  If this PR contains a breaking change,
  please also describe the impact and migration path for existing applications
-->

* [ ] Yes
* [ ] No

## Does this PR fix an open issue?

<!-- If this PR contain fixes to open issues please link them here -->

* [ ] Yes
* [ ] No
