### PR TITLE
fix(testrunner): handle coldcard now emitting low-s signatures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23371,9 +23371,9 @@
       "optional": true
     },
     "unchained-bitcoin": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/unchained-bitcoin/-/unchained-bitcoin-0.1.6.tgz",
-      "integrity": "sha512-EBKF95NcPPvHh0ygkViOxWPoQYv9ZY2G6MntZXSJvmrzpXaHGUqVNJZNYAidSuN/LTsJzPgTJuqROcAVH7iYUw==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/unchained-bitcoin/-/unchained-bitcoin-0.1.7.tgz",
+      "integrity": "sha512-teBLqGdiBlmDn6rpLUWnCnnlbMhRTiY1RbYSUJCoV26NEee5VfOb5Td7AxKypEyEY2oaJldCyi7X98boWOUWaw==",
       "requires": {
         "@babel/polyfill": "^7.7.0",
         "bignumber.js": "^8.1.1",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "redux-promise": "^0.6.0",
     "redux-thunk": "^2.3.0",
     "reselect": "^4.0.0",
-    "unchained-bitcoin": "^0.1.6",
+    "unchained-bitcoin": "^0.1.7",
     "unchained-wallets": "^0.1.21"
   }
 }

--- a/src/tests/signing.jsx
+++ b/src/tests/signing.jsx
@@ -7,7 +7,7 @@ import {
   unsignedTransactionObjectFromPSBT,
   TEST_FIXTURES,
 } from "unchained-bitcoin";
-import { HERMIT, SignMultisigTransaction } from "unchained-wallets";
+import { COLDCARD, HERMIT, SignMultisigTransaction } from "unchained-wallets";
 import { Box, Table, TableBody, TableRow, TableCell } from "@material-ui/core";
 import { externalLink } from "../utils";
 import Test from "./Test";
@@ -143,6 +143,9 @@ class SignMultisigTransactionTest extends Test {
   }
 
   expected() {
+    if (this.params.keystore === COLDCARD) {
+      return this.params.byteCeilingSignature;
+    }
     return this.params.signature;
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!---
  Please describe your change(s) in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

New Coldcard firmware grinds signature nonces to output smaller signatures. Fixtures updated in `unchained-bitcoin` and branch on `keystore === COLDCARD` ... means old firmware wont work now, but way code is structured means it's either or.

## Does this PR introduce a breaking change?

<!--
  If this PR contains a breaking change,
  please also describe the impact and migration path for existing applications
-->

* [x] Yes
* [ ] No

Old firmware signatures from Coldcard won't pass the test suite anymore.

## Does this PR fix an open issue?

<!-- If this PR contain fixes to open issues please link them here -->

* [ ] Yes
* [x] No
