### PR TITLE
Adds docker container with nginx config

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,40 @@
+*~
+*.pyc
+*.idea
+.DS_STORE
+.virtualenv/*
+node_modules/*
+TAGS
+.nfs*
+.coverage
+npm-debug.log
+*.swp
+.vscode
+junit.xml
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+coverage
+/coverage
+
+# production
+build
+/build
+
+# misc
+.DS_Store
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+code.html
+imports.html
+
+.git
+.github
+.gitignore
+.travis.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:14-buster as installer
+RUN mkdir -p /srv/caravan
+WORKDIR /srv/caravan
+COPY ./ .
+RUN npm install
+RUN npx browserslist@latest --update-db
+
+FROM installer as builder
+RUN npm run build
+
+FROM nginx as caravan
+COPY --from=builder /srv/caravan/build /srv/caravan
+COPY ./nginx.conf /etc/nginx/conf.d/default.conf
+RUN ln -s /srv/caravan /srv/caravan/caravan
+
+EXPOSE 80
+EXPOSE 3034
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,56 @@
+server {
+    listen       80;
+    server_name  _;
+
+    location /healthz {
+        access_log off;
+        default_type text/plain;
+        return 200 "healthy\n";
+    }
+
+    location / {
+        root   /srv/caravan;
+        index  index.html index.htm;
+        try_files $uri $uri/ /index.html;
+    }
+}
+
+# change this to an accessible reference for your node
+upstream bitcoind {
+  server bitcoind:18443;
+}
+
+server {
+  listen 3034;
+  server_name bitcoind;
+
+  location / {
+    if ($request_method = 'OPTIONS') {
+      add_header 'Access-Control-Allow-Origin' '*' always;
+      add_header 'Access-Control-Allow-Methods' 'POST, OPTIONS';
+      # Custom headers and headers various browsers *should* be OK with but aren't
+      add_header 'Access-Control-Allow-Headers' 'Authorization,Accept,Origin,DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
+      # Tell client that this pre-flight info is valid for 20 days
+      add_header 'Access-Control-Max-Age' 1728000;
+      add_header 'Content-Type' 'text/plain; charset=utf-8';
+      add_header 'Content-Length' 0;
+      return 204;
+    }
+
+    if ($request_method = 'POST') {
+      add_header 'Access-Control-Allow-Origin' '*' always;
+      add_header 'Access-Control-Allow-Methods' 'POST, OPTIONS';
+      # Custom headers and headers various browsers *should* be OK with but aren't
+      add_header 'Access-Control-Allow-Headers' 'Authorization,Accept,Origin,DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
+      add_header 'Access-Control-Allow-Credentials' 'true';
+      add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
+    }
+
+    proxy_pass http://bitcoind;
+    proxy_set_header Host $host;
+    proxy_set_header Accept-Encoding "";
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header Referer $http_referer;
+    proxy_set_header X-Forwarded-For "$http_x_forwarded_for, $realip_remote_addr";
+  }
+}


### PR DESCRIPTION
Allows for easier development locally with a private node.

If your node is accessible via `bitcoind` from inside the container, simply use `localhost:3034` as your private client and input your rpc credentials.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!---
  Please describe your change(s) in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

## Does this PR introduce a breaking change?

<!--
  If this PR contains a breaking change,
  please also describe the impact and migration path for existing applications
-->

* [ ] Yes
* [X] No

## Does this PR fix an open issue?

<!-- If this PR contain fixes to open issues please link them here -->

* [ ] Yes
* [X] No
