### PR TITLE
Add basic Dockerfile to build and serve the app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:14-buster-slim AS builder
+
+# Install all OS dependencies
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update --yes && \
+    apt-get upgrade --yes && \
+    apt-get install --yes --no-install-recommends \
+    build-essential
+
+# Copy over required files for build
+WORKDIR /var/app
+COPY config /var/app/config
+COPY fixtures /var/app/fixtures
+COPY public /var/app/public
+COPY src /var/app/src
+COPY .babelrc .env .eslintignore .eslintrc package-lock.json package.json /var/app/
+
+# Build the app
+RUN npm install
+RUN npm run build
+
+# Serve the production build files via nginx (will be served at http://localhost:80/caravan)
+FROM nginx:1.23
+COPY --from=builder /var/app/build /usr/share/nginx/html/caravan

--- a/README.md
+++ b/README.md
@@ -73,6 +73,22 @@ $ npm run build
 ...
 ```
 
+### Docker
+
+A basic dockerfile which builds the app and serves it via nginx is included in the repository
+
+To build the docker image:
+```bash
+docker build . -t caravan:latest
+```
+
+To run the built docker image:
+```bash
+docker run -p 80:8000 caravan:latest
+```
+
+Caravan should then be accessible at http://localhost:8000/caravan
+
 ## Usage
 
 If you can access the [Caravan web


### PR DESCRIPTION
## Description
Adds a basic dockerfile which builds the app and serves it via nginx.

Future work could include automating the build and publish of this image to dockerhub.

Even further future work could include making caravan available as an umbrel app.

## Does this PR introduce a breaking change?

* [ ] Yes
* [X] No

## Does this PR fix an open issue?

* [ ] Yes
* [X] No
