### PR TITLE
Wallet registrations and address verification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,8 +50,8 @@
         "redux-thunk": "^2.3.0",
         "reselect": "^4.0.0",
         "sass": "^1.56.2",
-        "unchained-bitcoin": "^0.3.0",
-        "unchained-wallets": "bucko13/unchained-wallets#ledger-address-verification"
+        "unchained-bitcoin": "^0.3.1",
+        "unchained-wallets": "^0.4.0"
       },
       "devDependencies": {
         "@babel/plugin-proposal-class-properties": "^7.8.3",
@@ -26174,9 +26174,9 @@
       }
     },
     "node_modules/unchained-bitcoin": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/unchained-bitcoin/-/unchained-bitcoin-0.3.0.tgz",
-      "integrity": "sha512-idGve5NQMf/7ZQysCabZWRTHs/+bjMuOq5HbjlGm2KHzqVsXkUTz/LjHMKFID0A5694LR69cnCN18z5YUWyMiw==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/unchained-bitcoin/-/unchained-bitcoin-0.3.1.tgz",
+      "integrity": "sha512-avwHRj8EeTqczeESAogLmTdn3aukKwq+tIfU987H5ZC858xnF0MEolAkHuy0PKzfytS+LCJsUQj2sRL11pnr0A==",
       "dependencies": {
         "@babel/polyfill": "^7.7.0",
         "bignumber.js": "^8.1.1",
@@ -26218,9 +26218,9 @@
       }
     },
     "node_modules/unchained-wallets": {
-      "version": "0.2.3",
-      "resolved": "git+ssh://git@github.com/bucko13/unchained-wallets.git#2a96dc9eae7621a1c5b0a6cc8cd55cc94a338b1e",
-      "license": "MIT",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/unchained-wallets/-/unchained-wallets-0.4.0.tgz",
+      "integrity": "sha512-G04/12Ofx3TRFhlLwAh1HMNaQkhcJza5JTB18qFTYJtlnin1guFaZ3eM3z1v5AC8ZbiPvxbqo7ln5Cj3e1nLRg==",
       "dependencies": {
         "@babel/polyfill": "^7.7.0",
         "@ledgerhq/hw-app-btc": "^5.34.1",
@@ -26234,7 +26234,7 @@
         "core-js": "^2.6.10",
         "punycode": "^2.1.1",
         "sha": "^3.0.0",
-        "unchained-bitcoin": "^0.3.0"
+        "unchained-bitcoin": "^0.3.1"
       },
       "engines": {
         "node": ">=16"
@@ -49035,9 +49035,9 @@
       "optional": true
     },
     "unchained-bitcoin": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/unchained-bitcoin/-/unchained-bitcoin-0.3.0.tgz",
-      "integrity": "sha512-idGve5NQMf/7ZQysCabZWRTHs/+bjMuOq5HbjlGm2KHzqVsXkUTz/LjHMKFID0A5694LR69cnCN18z5YUWyMiw==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/unchained-bitcoin/-/unchained-bitcoin-0.3.1.tgz",
+      "integrity": "sha512-avwHRj8EeTqczeESAogLmTdn3aukKwq+tIfU987H5ZC858xnF0MEolAkHuy0PKzfytS+LCJsUQj2sRL11pnr0A==",
       "requires": {
         "@babel/polyfill": "^7.7.0",
         "bignumber.js": "^8.1.1",
@@ -49075,8 +49075,9 @@
       }
     },
     "unchained-wallets": {
-      "version": "git+ssh://git@github.com/bucko13/unchained-wallets.git#2a96dc9eae7621a1c5b0a6cc8cd55cc94a338b1e",
-      "from": "unchained-wallets@bucko13/unchained-wallets#ledger-address-verification",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/unchained-wallets/-/unchained-wallets-0.4.0.tgz",
+      "integrity": "sha512-G04/12Ofx3TRFhlLwAh1HMNaQkhcJza5JTB18qFTYJtlnin1guFaZ3eM3z1v5AC8ZbiPvxbqo7ln5Cj3e1nLRg==",
       "requires": {
         "@babel/polyfill": "^7.7.0",
         "@ledgerhq/hw-app-btc": "^5.34.1",
@@ -49090,7 +49091,7 @@
         "core-js": "^2.6.10",
         "punycode": "^2.1.1",
         "sha": "^3.0.0",
-        "unchained-bitcoin": "^0.3.0"
+        "unchained-bitcoin": "^0.3.1"
       },
       "dependencies": {
         "bignumber.js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
-        "@material-ui/core": "^4.9.11",
+        "@material-ui/core": "^4.12.4",
         "@material-ui/icons": "^4.5.1",
         "@material-ui/lab": "^4.0.0-alpha.56",
         "axios": "^0.21.2",
@@ -51,7 +51,7 @@
         "reselect": "^4.0.0",
         "sass": "^1.56.2",
         "unchained-bitcoin": "^0.3.0",
-        "unchained-wallets": "^0.2.3"
+        "unchained-wallets": "bucko13/unchained-wallets#ledger-address-verification"
       },
       "devDependencies": {
         "@babel/plugin-proposal-class-properties": "^7.8.3",
@@ -3476,26 +3476,40 @@
       "integrity": "sha512-swKHYCOZUGyVt4ge0u8a7AwNcA//h4nx5wIi0sruGye1IJ5Cva0GyK9L2/WdX+kWVTKp92ZiEo1df31lrWGPgA=="
     },
     "node_modules/@material-ui/core": {
-      "version": "4.9.13",
-      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.9.13.tgz",
-      "integrity": "sha512-GEXNwUr+laZ0N+F1efmHB64Fyg+uQIRXLqbSejg3ebSXgLYNpIjnMOPRfWdu4rICq0dAIgvvNXGkKDMcf3AMpA==",
+      "version": "4.12.4",
+      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.12.4.tgz",
+      "integrity": "sha512-tr7xekNlM9LjA6pagJmL8QCgZXaubWUwkJnoYcMKd4gw/t4XiyvnTkjdGrUVicyB2BsdaAv1tvow45bPM4sSwQ==",
+      "deprecated": "Material UI v4 doesn't receive active development since September 2021. See the guide https://mui.com/material-ui/migration/migration-v4/ to upgrade to v5.",
       "dependencies": {
         "@babel/runtime": "^7.4.4",
-        "@material-ui/react-transition-group": "^4.3.0",
-        "@material-ui/styles": "^4.9.13",
-        "@material-ui/system": "^4.9.13",
-        "@material-ui/types": "^5.0.1",
-        "@material-ui/utils": "^4.9.12",
+        "@material-ui/styles": "^4.11.5",
+        "@material-ui/system": "^4.12.2",
+        "@material-ui/types": "5.1.0",
+        "@material-ui/utils": "^4.11.3",
         "@types/react-transition-group": "^4.2.0",
         "clsx": "^1.0.4",
         "hoist-non-react-statics": "^3.3.2",
-        "popper.js": "^1.16.1-lts",
+        "popper.js": "1.16.1-lts",
         "prop-types": "^15.7.2",
-        "react-is": "^16.8.0",
-        "react-transition-group": "^4.3.0"
+        "react-is": "^16.8.0 || ^17.0.0",
+        "react-transition-group": "^4.4.0"
       },
       "engines": {
         "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/material-ui"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.6 || ^17.0.0",
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@material-ui/icons": {
@@ -3524,19 +3538,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/@material-ui/lab/node_modules/@material-ui/utils": {
-      "version": "4.10.2",
-      "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.10.2.tgz",
-      "integrity": "sha512-eg29v74P7W5r6a4tWWDAAfZldXIzfyO1am2fIsC39hdUUHm/33k6pGOKPbgDjg/U/4ifmgAePy/1OjkKN6rFRw==",
-      "dependencies": {
-        "@babel/runtime": "^7.4.4",
-        "prop-types": "^15.7.2",
-        "react-is": "^16.8.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/@material-ui/pickers": {
       "version": "3.2.10",
       "resolved": "https://registry.npmjs.org/@material-ui/pickers/-/pickers-3.2.10.tgz",
@@ -3550,72 +3551,103 @@
         "rifm": "^0.7.0"
       }
     },
-    "node_modules/@material-ui/react-transition-group": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@material-ui/react-transition-group/-/react-transition-group-4.3.0.tgz",
-      "integrity": "sha512-CwQ0aXrlUynUTY6sh3UvKuvye1o92en20VGAs6TORnSxUYeRmkX8YeTUN3lAkGiBX1z222FxLFO36WWh6q73rQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "dom-helpers": "^5.0.1",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2"
-      }
-    },
     "node_modules/@material-ui/styles": {
-      "version": "4.9.13",
-      "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.9.13.tgz",
-      "integrity": "sha512-lWlXJanBdHQ18jW/yphedRokHcvZD1GdGzUF/wQxKDsHwDDfO45ZkAxuSBI202dG+r1Ph483Z3pFykO2obeSRA==",
+      "version": "4.11.5",
+      "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.11.5.tgz",
+      "integrity": "sha512-o/41ot5JJiUsIETME9wVLAJrmIWL3j0R0Bj2kCOLbSfqEkKf0fmaPt+5vtblUh5eXr2S+J/8J3DaCb10+CzPGA==",
+      "deprecated": "Material UI v4 doesn't receive active development since September 2021. See the guide https://mui.com/material-ui/migration/migration-v4/ to upgrade to v5.",
       "dependencies": {
         "@babel/runtime": "^7.4.4",
         "@emotion/hash": "^0.8.0",
-        "@material-ui/types": "^5.0.1",
-        "@material-ui/utils": "^4.9.6",
+        "@material-ui/types": "5.1.0",
+        "@material-ui/utils": "^4.11.3",
         "clsx": "^1.0.4",
         "csstype": "^2.5.2",
         "hoist-non-react-statics": "^3.3.2",
-        "jss": "^10.0.3",
-        "jss-plugin-camel-case": "^10.0.3",
-        "jss-plugin-default-unit": "^10.0.3",
-        "jss-plugin-global": "^10.0.3",
-        "jss-plugin-nested": "^10.0.3",
-        "jss-plugin-props-sort": "^10.0.3",
-        "jss-plugin-rule-value-function": "^10.0.3",
-        "jss-plugin-vendor-prefixer": "^10.0.3",
+        "jss": "^10.5.1",
+        "jss-plugin-camel-case": "^10.5.1",
+        "jss-plugin-default-unit": "^10.5.1",
+        "jss-plugin-global": "^10.5.1",
+        "jss-plugin-nested": "^10.5.1",
+        "jss-plugin-props-sort": "^10.5.1",
+        "jss-plugin-rule-value-function": "^10.5.1",
+        "jss-plugin-vendor-prefixer": "^10.5.1",
         "prop-types": "^15.7.2"
       },
       "engines": {
         "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/material-ui"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.6 || ^17.0.0",
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@material-ui/system": {
-      "version": "4.9.13",
-      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.9.13.tgz",
-      "integrity": "sha512-6AlpvdW6KJJ5bF1Xo2OD13sCN8k+nlL36412/bWnWZOKIfIMo/Lb8c8d1DOIaT/RKWxTEUaWnKZjabVnA3eZjA==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.12.2.tgz",
+      "integrity": "sha512-6CSKu2MtmiJgcCGf6nBQpM8fLkuB9F55EKfbdTC80NND5wpTmKzwdhLYLH3zL4cLlK0gVaaltW7/wMuyTnN0Lw==",
       "dependencies": {
         "@babel/runtime": "^7.4.4",
-        "@material-ui/utils": "^4.9.6",
+        "@material-ui/utils": "^4.11.3",
+        "csstype": "^2.5.2",
         "prop-types": "^15.7.2"
       },
       "engines": {
         "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/material-ui"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.6 || ^17.0.0",
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@material-ui/types": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-5.1.0.tgz",
-      "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A=="
+      "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A==",
+      "peerDependencies": {
+        "@types/react": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@material-ui/utils": {
-      "version": "4.9.12",
-      "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.9.12.tgz",
-      "integrity": "sha512-/0rgZPEOcZq5CFA4+4n6Q6zk7fi8skHhH2Bcra8R3epoJEYy5PL55LuMazPtPH1oKeRausDV/Omz4BbgFsn1HQ==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.11.3.tgz",
+      "integrity": "sha512-ZuQPV4rBK/V1j2dIkSSEcH5uT6AaHuKWFfotADHsC0wVL1NLd2WkFCm4ZZbX33iO4ydl6V0GPngKm8HZQ2oujg==",
       "dependencies": {
         "@babel/runtime": "^7.4.4",
         "prop-types": "^15.7.2",
-        "react-is": "^16.8.0"
+        "react-is": "^16.8.0 || ^17.0.0"
       },
       "engines": {
         "node": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0"
       }
     },
     "node_modules/@mrmlnc/readdir-enhanced": {
@@ -4243,24 +4275,24 @@
       }
     },
     "node_modules/@trezor/blockchain-link": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@trezor/blockchain-link/-/blockchain-link-2.1.7.tgz",
-      "integrity": "sha512-aX6eXNLRf2r04C4PTM9aOctw0e1Cpn2OvpVlWikGm+UOQfw/2aMpvwi2qu1Exo7Tnpno5Z2fWXrhq760lascpQ==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@trezor/blockchain-link/-/blockchain-link-2.1.8.tgz",
+      "integrity": "sha512-U42+SMUTyMoxm92wETtpIkrWH2SqkG42qq9F55KHMfu1Lt6rkrxhcDjnvmgcvTjmr9qxGmKe0vPtB/l3qH0aGQ==",
       "dependencies": {
-        "@trezor/utils": "^9.0.5",
-        "@trezor/utxo-lib": "^1.0.3",
-        "@types/web": "^0.0.80",
-        "bignumber.js": "^9.1.0",
+        "@trezor/utils": "^9.0.6",
+        "@trezor/utxo-lib": "^1.0.4",
+        "@types/web": "^0.0.91",
+        "bignumber.js": "^9.1.1",
         "events": "^3.3.0",
-        "ripple-lib": "1.10.0",
+        "ripple-lib": "^1.10.1",
         "socks-proxy-agent": "6.1.1",
-        "ws": "7.4.6"
+        "ws": "7.5.9"
       }
     },
     "node_modules/@trezor/blockchain-link/node_modules/ws": {
-      "version": "7.4.6",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
       "engines": {
         "node": ">=8.3.0"
       },
@@ -4324,43 +4356,29 @@
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@trezor/transport": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@trezor/transport/-/transport-1.1.7.tgz",
-      "integrity": "sha512-Xr9ArlHrSBUTKyPgVpYEOXkL3IHnm2FaoDtO+f6steyj5UEzeJDfwu8NhKdZ67C4j5298+KlzZdWKa1HPESKzA==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@trezor/transport/-/transport-1.1.8.tgz",
+      "integrity": "sha512-Q5X0vTaZQu21PqaHL1Dnm6TVSsuK1mweMWRo2PDioDErSDlQrTMt/81gUV+HHZq/ej2m4C6YHx74pTlo2zJkfQ==",
       "dependencies": {
-        "@trezor/utils": "^9.0.5",
+        "@trezor/utils": "^9.0.6",
         "bytebuffer": "^5.0.1",
         "json-stable-stringify": "^1.0.2",
         "long": "^4.0.0",
-        "prettier": "2.8.0",
+        "prettier": "2.8.4",
         "protobufjs": "^6.11.3"
       }
     },
-    "node_modules/@trezor/transport/node_modules/prettier": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.0.tgz",
-      "integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA==",
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
     "node_modules/@trezor/utils": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/@trezor/utils/-/utils-9.0.5.tgz",
-      "integrity": "sha512-sUYE9ZLkfKcvidME/TXqKVDe821zSy0aJ5IkK2uy94b3kmD2uv3Drt7YfOcR6M49FYeiptrxqz1FnL2tg+JwTw=="
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@trezor/utils/-/utils-9.0.6.tgz",
+      "integrity": "sha512-ZrZDMa1DzcfptBTdIPd7jLJGd03EVbocCSa92o64Qb6FMGSUh+t8Y+9Yy6rBPN1GTOsJxVQmcj3leKrtJMgwVQ=="
     },
     "node_modules/@trezor/utxo-lib": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@trezor/utxo-lib/-/utxo-lib-1.0.3.tgz",
-      "integrity": "sha512-epWH8WsFpw1ak2hWqW9Ep9hEjkL2vRheIAvIc4kwz8cGXhZXEG3Aaufx57HWg1ean48xFVtnsYEURVMzakycFA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@trezor/utxo-lib/-/utxo-lib-1.0.4.tgz",
+      "integrity": "sha512-n4Xj2YIpqRKaZiDZww0mcY0c2ZN+SDygR3dAJkUb7O/2FykxCS28z3QHIjfbdzMwquywbkxDeiErcdrHw3GIvg==",
       "dependencies": {
-        "@trezor/utils": "^9.0.5",
+        "@trezor/utils": "^9.0.6",
         "bchaddrjs": "^0.5.2",
         "bech32": "^2.0.0",
         "bip66": "^1.1.5",
@@ -4998,9 +5016,9 @@
       "integrity": "sha1-DSUBJorY+ZYrdA04fEZU9fjiPlI="
     },
     "node_modules/@types/web": {
-      "version": "0.0.80",
-      "resolved": "https://registry.npmjs.org/@types/web/-/web-0.0.80.tgz",
-      "integrity": "sha512-HLbRwqCL5VVkmpAAzqRGXDkUO4teKhOOY2FJDHQl3k5OTuDTPzkI74AJSoGaS6oHOVVYhI/X5Ahw/ltC8KZQuw=="
+      "version": "0.0.91",
+      "resolved": "https://registry.npmjs.org/@types/web/-/web-0.0.91.tgz",
+      "integrity": "sha512-KIw/1SNDyzPMpN7JiS2TTmiKXUhg4vkV2b8ozgQV0aw82dZr1chPXyunxVbUjSHaDrLxQbD+xpVk+CXiVkakHg=="
     },
     "node_modules/@types/ws": {
       "version": "7.4.7",
@@ -15357,9 +15375,9 @@
       }
     },
     "node_modules/hyphenate-style-name": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz",
-      "integrity": "sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
@@ -15985,7 +16003,7 @@
     "node_modules/is-in-browser": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
-      "integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU="
+      "integrity": "sha512-FeXIBgG/CPGd/WUxuEyvgGTEfwiG9Z4EKGxjNMRqviiIIfsmgrpnHLffEDdwUHqNva1VEW91o3xBT/m8Elgl9g=="
     },
     "node_modules/is-nan": {
       "version": "1.3.2",
@@ -17807,81 +17825,91 @@
       "integrity": "sha512-zCTP6Qd/WwjrpuHFkJuXc5opRdKprUr7eI7+JCCtcetThJt45qptu82MWQ+eET+FtDrMo7+BYjo3iD0XIq1L9Q=="
     },
     "node_modules/jss": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/jss/-/jss-10.1.1.tgz",
-      "integrity": "sha512-Xz3qgRUFlxbWk1czCZibUJqhVPObrZHxY3FPsjCXhDld4NOj1BgM14Ir5hVm+Qr6OLqVljjGvoMcCdXNOAbdkQ==",
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss/-/jss-10.10.0.tgz",
+      "integrity": "sha512-cqsOTS7jqPsPMjtKYDUpdFC0AbhYFLTcuGRqymgmdJIeQ8cH7+AgX7YSgQy79wXloZq2VvATYxUOUQEvS1V/Zw==",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
-        "csstype": "^2.6.5",
+        "csstype": "^3.0.2",
         "is-in-browser": "^1.1.3",
         "tiny-warning": "^1.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/jss"
       }
     },
     "node_modules/jss-plugin-camel-case": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.1.1.tgz",
-      "integrity": "sha512-MDIaw8FeD5uFz1seQBKz4pnvDLnj5vIKV5hXSVdMaAVq13xR6SVTVWkIV/keyTs5txxTvzGJ9hXoxgd1WTUlBw==",
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.10.0.tgz",
+      "integrity": "sha512-z+HETfj5IYgFxh1wJnUAU8jByI48ED+v0fuTuhKrPR+pRBYS2EDwbusU8aFOpCdYhtRc9zhN+PJ7iNE8pAWyPw==",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
         "hyphenate-style-name": "^1.0.3",
-        "jss": "10.1.1"
+        "jss": "10.10.0"
       }
     },
     "node_modules/jss-plugin-default-unit": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.1.1.tgz",
-      "integrity": "sha512-UkeVCA/b3QEA4k0nIKS4uWXDCNmV73WLHdh2oDGZZc3GsQtlOCuiH3EkB/qI60v2MiCq356/SYWsDXt21yjwdg==",
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.10.0.tgz",
+      "integrity": "sha512-SvpajxIECi4JDUbGLefvNckmI+c2VWmP43qnEy/0eiwzRUsafg5DVSIWSzZe4d2vFX1u9nRDP46WCFV/PXVBGQ==",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.1.1"
+        "jss": "10.10.0"
       }
     },
     "node_modules/jss-plugin-global": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.1.1.tgz",
-      "integrity": "sha512-VBG3wRyi3Z8S4kMhm8rZV6caYBegsk+QnQZSVmrWw6GVOT/Z4FA7eyMu5SdkorDlG/HVpHh91oFN56O4R9m2VA==",
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.10.0.tgz",
+      "integrity": "sha512-icXEYbMufiNuWfuazLeN+BNJO16Ge88OcXU5ZDC2vLqElmMybA31Wi7lZ3lf+vgufRocvPj8443irhYRgWxP+A==",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.1.1"
+        "jss": "10.10.0"
       }
     },
     "node_modules/jss-plugin-nested": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.1.1.tgz",
-      "integrity": "sha512-ozEu7ZBSVrMYxSDplPX3H82XHNQk2DQEJ9TEyo7OVTPJ1hEieqjDFiOQOxXEj9z3PMqkylnUbvWIZRDKCFYw5Q==",
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.10.0.tgz",
+      "integrity": "sha512-9R4JHxxGgiZhurDo3q7LdIiDEgtA1bTGzAbhSPyIOWb7ZubrjQe8acwhEQ6OEKydzpl8XHMtTnEwHXCARLYqYA==",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.1.1",
+        "jss": "10.10.0",
         "tiny-warning": "^1.0.2"
       }
     },
     "node_modules/jss-plugin-props-sort": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.1.1.tgz",
-      "integrity": "sha512-g/joK3eTDZB4pkqpZB38257yD4LXB0X15jxtZAGbUzcKAVUHPl9Jb47Y7lYmiGsShiV4YmQRqG1p2DHMYoK91g==",
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.10.0.tgz",
+      "integrity": "sha512-5VNJvQJbnq/vRfje6uZLe/FyaOpzP/IH1LP+0fr88QamVrGJa0hpRRyAa0ea4U/3LcorJfBFVyC4yN2QC73lJg==",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.1.1"
+        "jss": "10.10.0"
       }
     },
     "node_modules/jss-plugin-rule-value-function": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.1.1.tgz",
-      "integrity": "sha512-ClV1lvJ3laU9la1CUzaDugEcwnpjPTuJ0yGy2YtcU+gG/w9HMInD5vEv7xKAz53Bk4WiJm5uLOElSEshHyhKNw==",
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.10.0.tgz",
+      "integrity": "sha512-uEFJFgaCtkXeIPgki8ICw3Y7VMkL9GEan6SqmT9tqpwM+/t+hxfMUdU4wQ0MtOiMNWhwnckBV0IebrKcZM9C0g==",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.1.1"
+        "jss": "10.10.0",
+        "tiny-warning": "^1.0.2"
       }
     },
     "node_modules/jss-plugin-vendor-prefixer": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.1.1.tgz",
-      "integrity": "sha512-09MZpQ6onQrhaVSF6GHC4iYifQ7+4YC/tAP6D4ZWeZotvCMq1mHLqNKRIaqQ2lkgANjlEot2JnVi1ktu4+L4pw==",
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.10.0.tgz",
+      "integrity": "sha512-UY/41WumgjW8r1qMCO8l1ARg7NHnfRVWRhZ2E2m0DMYsr2DD91qIXLyNhiX83hHswR7Wm4D+oDYNC1zWCJWtqg==",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
-        "css-vendor": "^2.0.7",
-        "jss": "10.1.1"
+        "css-vendor": "^2.0.8",
+        "jss": "10.10.0"
       }
+    },
+    "node_modules/jss/node_modules/csstype": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
+      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
     },
     "node_modules/jsx-ast-utils": {
       "version": "2.2.3",
@@ -20274,9 +20302,9 @@
       }
     },
     "node_modules/popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
+      "version": "1.16.1-lts",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1-lts.tgz",
+      "integrity": "sha512-Kjw8nKRl1m+VrSFCoVGPph93W/qrSO7ZkqPpTf7F4bk/sqcfWK019dWBUpE/fBOsOQY1dks/Bmcbfn1heM/IsA=="
     },
     "node_modules/portfinder": {
       "version": "1.0.28",
@@ -21496,7 +21524,6 @@
       "version": "2.8.4",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
       "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
-      "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -21671,9 +21698,9 @@
       }
     },
     "node_modules/protobufjs/node_modules/@types/node": {
-      "version": "18.14.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.2.tgz",
-      "integrity": "sha512-1uEQxww3DaghA0RxqHx0O0ppVlo43pJhepY51OxuQIKHpjbnYLA7vcdwioNPzIqmC2u3I/dmylcqjlh0e7AyUA=="
+      "version": "18.15.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.0.tgz",
+      "integrity": "sha512-z6nr0TTEOBGkzLGmbypWOGnpSpSIBorEhC4L+4HeQ2iezKCi4f77kyslRwvHeNitymGQ+oFyIWGP96l/DPSV9w=="
     },
     "node_modules/proxy-addr": {
       "version": "2.0.6",
@@ -23339,11 +23366,11 @@
       }
     },
     "node_modules/ripple-address-codec": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/ripple-address-codec/-/ripple-address-codec-4.2.4.tgz",
-      "integrity": "sha512-roAOjKz94+FboTItey1XRh5qynwt4xvfBLvbbcx+FiR94Yw2x3LrKLF2GVCMCSAh5I6PkcpADg6AbYsUbGN3nA==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/ripple-address-codec/-/ripple-address-codec-4.2.5.tgz",
+      "integrity": "sha512-SZ96zZH+0REeyEcYVFl0vqcsGRXiFXS2RUgHupHhtVkOEk6men53vngVjJwBrSnY+oa6Cri15q1zSni3DEoxNw==",
       "dependencies": {
-        "base-x": "3.0.9",
+        "base-x": "^3.0.9",
         "create-hash": "^1.1.2"
       },
       "engines": {
@@ -23359,19 +23386,19 @@
       }
     },
     "node_modules/ripple-binary-codec": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/ripple-binary-codec/-/ripple-binary-codec-1.4.2.tgz",
-      "integrity": "sha512-EDKIyZMa/6Ay/oNgCwjD9b9CJv0zmBreeHVQeG4BYwy+9GPnIQjNeT5e/aB6OjAnhcmpgbPeBmzwmNVwzxlt0w==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/ripple-binary-codec/-/ripple-binary-codec-1.4.3.tgz",
+      "integrity": "sha512-P4ALjAJWBJpRApTQO+dJCrHE6mZxm7ypZot9OS0a3RCKOWTReNw0pDWfdhCGh1qXh71TeQnAk4CHdMLwR/76oQ==",
       "dependencies": {
         "assert": "^2.0.0",
         "big-integer": "^1.6.48",
         "buffer": "5.6.0",
         "create-hash": "^1.2.0",
         "decimal.js": "^10.2.0",
-        "ripple-address-codec": "^4.2.4"
+        "ripple-address-codec": "^4.2.5"
       },
       "engines": {
-        "node": ">=10.22.0"
+        "node": ">= 10"
       }
     },
     "node_modules/ripple-binary-codec/node_modules/assert": {
@@ -23415,15 +23442,15 @@
       }
     },
     "node_modules/ripple-keypairs": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/ripple-keypairs/-/ripple-keypairs-1.1.4.tgz",
-      "integrity": "sha512-PMMjTOxZmCSBOvHPj6bA+V/HGx7oFgDtGGI8VcZYuaFO2H87UX0X0jhfHy+LA2Xy31WYlD7GaDIDDt2QO+AMtw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ripple-keypairs/-/ripple-keypairs-1.1.5.tgz",
+      "integrity": "sha512-wLJXIBsMVazn2Yp/7oP4PvgA4Gd1HtuZLftdEJFNOLgraf82phqa2AnNK3t9f3XeQnApW1jAe/FcFFOY6QUn5w==",
       "dependencies": {
         "bn.js": "^5.1.1",
         "brorand": "^1.0.5",
         "elliptic": "^6.5.4",
         "hash.js": "^1.0.3",
-        "ripple-address-codec": "^4.2.4"
+        "ripple-address-codec": "^4.2.5"
       },
       "engines": {
         "node": ">= 10"
@@ -23435,9 +23462,9 @@
       "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
     },
     "node_modules/ripple-lib": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/ripple-lib/-/ripple-lib-1.10.0.tgz",
-      "integrity": "sha512-Cg2u73UybfM1PnzcuLt5flvLKZn35ovdIp+1eLrReVB4swuRuUF/SskJG9hf5wMosbvh+E+jZu8A6IbYJoyFIA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/ripple-lib/-/ripple-lib-1.10.1.tgz",
+      "integrity": "sha512-OQk+Syl2JfxKxV2KuF/kBMtnh012I5tNnziP3G4WDGCGSIAgeqkOgkR59IQ0YDNrs1YW8GbApxrdMSRi/QClcA==",
       "dependencies": {
         "@types/lodash": "^4.14.136",
         "@types/ws": "^7.2.0",
@@ -26192,8 +26219,8 @@
     },
     "node_modules/unchained-wallets": {
       "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/unchained-wallets/-/unchained-wallets-0.2.3.tgz",
-      "integrity": "sha512-o+Eh5lW+Vx0Za+R4nyxD2DBXcTO46SuPMWIco7c4BbRUEDIno9vIrIU+2ztCVkJ02N0+8o4GgcLWyibLYo1yvw==",
+      "resolved": "git+ssh://git@github.com/bucko13/unchained-wallets.git#2a96dc9eae7621a1c5b0a6cc8cd55cc94a338b1e",
+      "license": "MIT",
       "dependencies": {
         "@babel/polyfill": "^7.7.0",
         "@ledgerhq/hw-app-btc": "^5.34.1",
@@ -30424,23 +30451,22 @@
       "integrity": "sha512-swKHYCOZUGyVt4ge0u8a7AwNcA//h4nx5wIi0sruGye1IJ5Cva0GyK9L2/WdX+kWVTKp92ZiEo1df31lrWGPgA=="
     },
     "@material-ui/core": {
-      "version": "4.9.13",
-      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.9.13.tgz",
-      "integrity": "sha512-GEXNwUr+laZ0N+F1efmHB64Fyg+uQIRXLqbSejg3ebSXgLYNpIjnMOPRfWdu4rICq0dAIgvvNXGkKDMcf3AMpA==",
+      "version": "4.12.4",
+      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.12.4.tgz",
+      "integrity": "sha512-tr7xekNlM9LjA6pagJmL8QCgZXaubWUwkJnoYcMKd4gw/t4XiyvnTkjdGrUVicyB2BsdaAv1tvow45bPM4sSwQ==",
       "requires": {
         "@babel/runtime": "^7.4.4",
-        "@material-ui/react-transition-group": "^4.3.0",
-        "@material-ui/styles": "^4.9.13",
-        "@material-ui/system": "^4.9.13",
-        "@material-ui/types": "^5.0.1",
-        "@material-ui/utils": "^4.9.12",
+        "@material-ui/styles": "^4.11.5",
+        "@material-ui/system": "^4.12.2",
+        "@material-ui/types": "5.1.0",
+        "@material-ui/utils": "^4.11.3",
         "@types/react-transition-group": "^4.2.0",
         "clsx": "^1.0.4",
         "hoist-non-react-statics": "^3.3.2",
-        "popper.js": "^1.16.1-lts",
+        "popper.js": "1.16.1-lts",
         "prop-types": "^15.7.2",
-        "react-is": "^16.8.0",
-        "react-transition-group": "^4.3.0"
+        "react-is": "^16.8.0 || ^17.0.0",
+        "react-transition-group": "^4.4.0"
       }
     },
     "@material-ui/icons": {
@@ -30461,18 +30487,6 @@
         "clsx": "^1.0.4",
         "prop-types": "^15.7.2",
         "react-is": "^16.8.0"
-      },
-      "dependencies": {
-        "@material-ui/utils": {
-          "version": "4.10.2",
-          "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.10.2.tgz",
-          "integrity": "sha512-eg29v74P7W5r6a4tWWDAAfZldXIzfyO1am2fIsC39hdUUHm/33k6pGOKPbgDjg/U/4ifmgAePy/1OjkKN6rFRw==",
-          "requires": {
-            "@babel/runtime": "^7.4.4",
-            "prop-types": "^15.7.2",
-            "react-is": "^16.8.0"
-          }
-        }
       }
     },
     "@material-ui/pickers": {
@@ -30488,63 +30502,54 @@
         "rifm": "^0.7.0"
       }
     },
-    "@material-ui/react-transition-group": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@material-ui/react-transition-group/-/react-transition-group-4.3.0.tgz",
-      "integrity": "sha512-CwQ0aXrlUynUTY6sh3UvKuvye1o92en20VGAs6TORnSxUYeRmkX8YeTUN3lAkGiBX1z222FxLFO36WWh6q73rQ==",
-      "requires": {
-        "@babel/runtime": "^7.5.5",
-        "dom-helpers": "^5.0.1",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2"
-      }
-    },
     "@material-ui/styles": {
-      "version": "4.9.13",
-      "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.9.13.tgz",
-      "integrity": "sha512-lWlXJanBdHQ18jW/yphedRokHcvZD1GdGzUF/wQxKDsHwDDfO45ZkAxuSBI202dG+r1Ph483Z3pFykO2obeSRA==",
+      "version": "4.11.5",
+      "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.11.5.tgz",
+      "integrity": "sha512-o/41ot5JJiUsIETME9wVLAJrmIWL3j0R0Bj2kCOLbSfqEkKf0fmaPt+5vtblUh5eXr2S+J/8J3DaCb10+CzPGA==",
       "requires": {
         "@babel/runtime": "^7.4.4",
         "@emotion/hash": "^0.8.0",
-        "@material-ui/types": "^5.0.1",
-        "@material-ui/utils": "^4.9.6",
+        "@material-ui/types": "5.1.0",
+        "@material-ui/utils": "^4.11.3",
         "clsx": "^1.0.4",
         "csstype": "^2.5.2",
         "hoist-non-react-statics": "^3.3.2",
-        "jss": "^10.0.3",
-        "jss-plugin-camel-case": "^10.0.3",
-        "jss-plugin-default-unit": "^10.0.3",
-        "jss-plugin-global": "^10.0.3",
-        "jss-plugin-nested": "^10.0.3",
-        "jss-plugin-props-sort": "^10.0.3",
-        "jss-plugin-rule-value-function": "^10.0.3",
-        "jss-plugin-vendor-prefixer": "^10.0.3",
+        "jss": "^10.5.1",
+        "jss-plugin-camel-case": "^10.5.1",
+        "jss-plugin-default-unit": "^10.5.1",
+        "jss-plugin-global": "^10.5.1",
+        "jss-plugin-nested": "^10.5.1",
+        "jss-plugin-props-sort": "^10.5.1",
+        "jss-plugin-rule-value-function": "^10.5.1",
+        "jss-plugin-vendor-prefixer": "^10.5.1",
         "prop-types": "^15.7.2"
       }
     },
     "@material-ui/system": {
-      "version": "4.9.13",
-      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.9.13.tgz",
-      "integrity": "sha512-6AlpvdW6KJJ5bF1Xo2OD13sCN8k+nlL36412/bWnWZOKIfIMo/Lb8c8d1DOIaT/RKWxTEUaWnKZjabVnA3eZjA==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.12.2.tgz",
+      "integrity": "sha512-6CSKu2MtmiJgcCGf6nBQpM8fLkuB9F55EKfbdTC80NND5wpTmKzwdhLYLH3zL4cLlK0gVaaltW7/wMuyTnN0Lw==",
       "requires": {
         "@babel/runtime": "^7.4.4",
-        "@material-ui/utils": "^4.9.6",
+        "@material-ui/utils": "^4.11.3",
+        "csstype": "^2.5.2",
         "prop-types": "^15.7.2"
       }
     },
     "@material-ui/types": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-5.1.0.tgz",
-      "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A=="
+      "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A==",
+      "requires": {}
     },
     "@material-ui/utils": {
-      "version": "4.9.12",
-      "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.9.12.tgz",
-      "integrity": "sha512-/0rgZPEOcZq5CFA4+4n6Q6zk7fi8skHhH2Bcra8R3epoJEYy5PL55LuMazPtPH1oKeRausDV/Omz4BbgFsn1HQ==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.11.3.tgz",
+      "integrity": "sha512-ZuQPV4rBK/V1j2dIkSSEcH5uT6AaHuKWFfotADHsC0wVL1NLd2WkFCm4ZZbX33iO4ydl6V0GPngKm8HZQ2oujg==",
       "requires": {
         "@babel/runtime": "^7.4.4",
         "prop-types": "^15.7.2",
-        "react-is": "^16.8.0"
+        "react-is": "^16.8.0 || ^17.0.0"
       }
     },
     "@mrmlnc/readdir-enhanced": {
@@ -31044,24 +31049,24 @@
       }
     },
     "@trezor/blockchain-link": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@trezor/blockchain-link/-/blockchain-link-2.1.7.tgz",
-      "integrity": "sha512-aX6eXNLRf2r04C4PTM9aOctw0e1Cpn2OvpVlWikGm+UOQfw/2aMpvwi2qu1Exo7Tnpno5Z2fWXrhq760lascpQ==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@trezor/blockchain-link/-/blockchain-link-2.1.8.tgz",
+      "integrity": "sha512-U42+SMUTyMoxm92wETtpIkrWH2SqkG42qq9F55KHMfu1Lt6rkrxhcDjnvmgcvTjmr9qxGmKe0vPtB/l3qH0aGQ==",
       "requires": {
-        "@trezor/utils": "^9.0.5",
-        "@trezor/utxo-lib": "^1.0.3",
-        "@types/web": "^0.0.80",
-        "bignumber.js": "^9.1.0",
+        "@trezor/utils": "^9.0.6",
+        "@trezor/utxo-lib": "^1.0.4",
+        "@types/web": "^0.0.91",
+        "bignumber.js": "^9.1.1",
         "events": "^3.3.0",
-        "ripple-lib": "1.10.0",
+        "ripple-lib": "^1.10.1",
         "socks-proxy-agent": "6.1.1",
-        "ws": "7.4.6"
+        "ws": "7.5.9"
       },
       "dependencies": {
         "ws": {
-          "version": "7.4.6",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-          "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+          "version": "7.5.9",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+          "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
           "requires": {}
         }
       }
@@ -31117,36 +31122,29 @@
       }
     },
     "@trezor/transport": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@trezor/transport/-/transport-1.1.7.tgz",
-      "integrity": "sha512-Xr9ArlHrSBUTKyPgVpYEOXkL3IHnm2FaoDtO+f6steyj5UEzeJDfwu8NhKdZ67C4j5298+KlzZdWKa1HPESKzA==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@trezor/transport/-/transport-1.1.8.tgz",
+      "integrity": "sha512-Q5X0vTaZQu21PqaHL1Dnm6TVSsuK1mweMWRo2PDioDErSDlQrTMt/81gUV+HHZq/ej2m4C6YHx74pTlo2zJkfQ==",
       "requires": {
-        "@trezor/utils": "^9.0.5",
+        "@trezor/utils": "^9.0.6",
         "bytebuffer": "^5.0.1",
         "json-stable-stringify": "^1.0.2",
         "long": "^4.0.0",
-        "prettier": "2.8.0",
+        "prettier": "2.8.4",
         "protobufjs": "^6.11.3"
-      },
-      "dependencies": {
-        "prettier": {
-          "version": "2.8.0",
-          "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.0.tgz",
-          "integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA=="
-        }
       }
     },
     "@trezor/utils": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/@trezor/utils/-/utils-9.0.5.tgz",
-      "integrity": "sha512-sUYE9ZLkfKcvidME/TXqKVDe821zSy0aJ5IkK2uy94b3kmD2uv3Drt7YfOcR6M49FYeiptrxqz1FnL2tg+JwTw=="
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@trezor/utils/-/utils-9.0.6.tgz",
+      "integrity": "sha512-ZrZDMa1DzcfptBTdIPd7jLJGd03EVbocCSa92o64Qb6FMGSUh+t8Y+9Yy6rBPN1GTOsJxVQmcj3leKrtJMgwVQ=="
     },
     "@trezor/utxo-lib": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@trezor/utxo-lib/-/utxo-lib-1.0.3.tgz",
-      "integrity": "sha512-epWH8WsFpw1ak2hWqW9Ep9hEjkL2vRheIAvIc4kwz8cGXhZXEG3Aaufx57HWg1ean48xFVtnsYEURVMzakycFA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@trezor/utxo-lib/-/utxo-lib-1.0.4.tgz",
+      "integrity": "sha512-n4Xj2YIpqRKaZiDZww0mcY0c2ZN+SDygR3dAJkUb7O/2FykxCS28z3QHIjfbdzMwquywbkxDeiErcdrHw3GIvg==",
       "requires": {
-        "@trezor/utils": "^9.0.5",
+        "@trezor/utils": "^9.0.6",
         "bchaddrjs": "^0.5.2",
         "bech32": "^2.0.0",
         "bip66": "^1.1.5",
@@ -31711,9 +31709,9 @@
       "integrity": "sha1-DSUBJorY+ZYrdA04fEZU9fjiPlI="
     },
     "@types/web": {
-      "version": "0.0.80",
-      "resolved": "https://registry.npmjs.org/@types/web/-/web-0.0.80.tgz",
-      "integrity": "sha512-HLbRwqCL5VVkmpAAzqRGXDkUO4teKhOOY2FJDHQl3k5OTuDTPzkI74AJSoGaS6oHOVVYhI/X5Ahw/ltC8KZQuw=="
+      "version": "0.0.91",
+      "resolved": "https://registry.npmjs.org/@types/web/-/web-0.0.91.tgz",
+      "integrity": "sha512-KIw/1SNDyzPMpN7JiS2TTmiKXUhg4vkV2b8ozgQV0aw82dZr1chPXyunxVbUjSHaDrLxQbD+xpVk+CXiVkakHg=="
     },
     "@types/ws": {
       "version": "7.4.7",
@@ -40230,9 +40228,9 @@
       }
     },
     "hyphenate-style-name": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz",
-      "integrity": "sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -40689,7 +40687,7 @@
     "is-in-browser": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
-      "integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU="
+      "integrity": "sha512-FeXIBgG/CPGd/WUxuEyvgGTEfwiG9Z4EKGxjNMRqviiIIfsmgrpnHLffEDdwUHqNva1VEW91o3xBT/m8Elgl9g=="
     },
     "is-nan": {
       "version": "1.3.2",
@@ -42125,80 +42123,88 @@
       "integrity": "sha512-zCTP6Qd/WwjrpuHFkJuXc5opRdKprUr7eI7+JCCtcetThJt45qptu82MWQ+eET+FtDrMo7+BYjo3iD0XIq1L9Q=="
     },
     "jss": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/jss/-/jss-10.1.1.tgz",
-      "integrity": "sha512-Xz3qgRUFlxbWk1czCZibUJqhVPObrZHxY3FPsjCXhDld4NOj1BgM14Ir5hVm+Qr6OLqVljjGvoMcCdXNOAbdkQ==",
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss/-/jss-10.10.0.tgz",
+      "integrity": "sha512-cqsOTS7jqPsPMjtKYDUpdFC0AbhYFLTcuGRqymgmdJIeQ8cH7+AgX7YSgQy79wXloZq2VvATYxUOUQEvS1V/Zw==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "csstype": "^2.6.5",
+        "csstype": "^3.0.2",
         "is-in-browser": "^1.1.3",
         "tiny-warning": "^1.0.2"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
+          "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
+        }
       }
     },
     "jss-plugin-camel-case": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.1.1.tgz",
-      "integrity": "sha512-MDIaw8FeD5uFz1seQBKz4pnvDLnj5vIKV5hXSVdMaAVq13xR6SVTVWkIV/keyTs5txxTvzGJ9hXoxgd1WTUlBw==",
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.10.0.tgz",
+      "integrity": "sha512-z+HETfj5IYgFxh1wJnUAU8jByI48ED+v0fuTuhKrPR+pRBYS2EDwbusU8aFOpCdYhtRc9zhN+PJ7iNE8pAWyPw==",
       "requires": {
         "@babel/runtime": "^7.3.1",
         "hyphenate-style-name": "^1.0.3",
-        "jss": "10.1.1"
+        "jss": "10.10.0"
       }
     },
     "jss-plugin-default-unit": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.1.1.tgz",
-      "integrity": "sha512-UkeVCA/b3QEA4k0nIKS4uWXDCNmV73WLHdh2oDGZZc3GsQtlOCuiH3EkB/qI60v2MiCq356/SYWsDXt21yjwdg==",
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.10.0.tgz",
+      "integrity": "sha512-SvpajxIECi4JDUbGLefvNckmI+c2VWmP43qnEy/0eiwzRUsafg5DVSIWSzZe4d2vFX1u9nRDP46WCFV/PXVBGQ==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.1.1"
+        "jss": "10.10.0"
       }
     },
     "jss-plugin-global": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.1.1.tgz",
-      "integrity": "sha512-VBG3wRyi3Z8S4kMhm8rZV6caYBegsk+QnQZSVmrWw6GVOT/Z4FA7eyMu5SdkorDlG/HVpHh91oFN56O4R9m2VA==",
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.10.0.tgz",
+      "integrity": "sha512-icXEYbMufiNuWfuazLeN+BNJO16Ge88OcXU5ZDC2vLqElmMybA31Wi7lZ3lf+vgufRocvPj8443irhYRgWxP+A==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.1.1"
+        "jss": "10.10.0"
       }
     },
     "jss-plugin-nested": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.1.1.tgz",
-      "integrity": "sha512-ozEu7ZBSVrMYxSDplPX3H82XHNQk2DQEJ9TEyo7OVTPJ1hEieqjDFiOQOxXEj9z3PMqkylnUbvWIZRDKCFYw5Q==",
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.10.0.tgz",
+      "integrity": "sha512-9R4JHxxGgiZhurDo3q7LdIiDEgtA1bTGzAbhSPyIOWb7ZubrjQe8acwhEQ6OEKydzpl8XHMtTnEwHXCARLYqYA==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.1.1",
+        "jss": "10.10.0",
         "tiny-warning": "^1.0.2"
       }
     },
     "jss-plugin-props-sort": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.1.1.tgz",
-      "integrity": "sha512-g/joK3eTDZB4pkqpZB38257yD4LXB0X15jxtZAGbUzcKAVUHPl9Jb47Y7lYmiGsShiV4YmQRqG1p2DHMYoK91g==",
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.10.0.tgz",
+      "integrity": "sha512-5VNJvQJbnq/vRfje6uZLe/FyaOpzP/IH1LP+0fr88QamVrGJa0hpRRyAa0ea4U/3LcorJfBFVyC4yN2QC73lJg==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.1.1"
+        "jss": "10.10.0"
       }
     },
     "jss-plugin-rule-value-function": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.1.1.tgz",
-      "integrity": "sha512-ClV1lvJ3laU9la1CUzaDugEcwnpjPTuJ0yGy2YtcU+gG/w9HMInD5vEv7xKAz53Bk4WiJm5uLOElSEshHyhKNw==",
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.10.0.tgz",
+      "integrity": "sha512-uEFJFgaCtkXeIPgki8ICw3Y7VMkL9GEan6SqmT9tqpwM+/t+hxfMUdU4wQ0MtOiMNWhwnckBV0IebrKcZM9C0g==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.1.1"
+        "jss": "10.10.0",
+        "tiny-warning": "^1.0.2"
       }
     },
     "jss-plugin-vendor-prefixer": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.1.1.tgz",
-      "integrity": "sha512-09MZpQ6onQrhaVSF6GHC4iYifQ7+4YC/tAP6D4ZWeZotvCMq1mHLqNKRIaqQ2lkgANjlEot2JnVi1ktu4+L4pw==",
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.10.0.tgz",
+      "integrity": "sha512-UY/41WumgjW8r1qMCO8l1ARg7NHnfRVWRhZ2E2m0DMYsr2DD91qIXLyNhiX83hHswR7Wm4D+oDYNC1zWCJWtqg==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "css-vendor": "^2.0.7",
-        "jss": "10.1.1"
+        "css-vendor": "^2.0.8",
+        "jss": "10.10.0"
       }
     },
     "jsx-ast-utils": {
@@ -44186,9 +44192,9 @@
       }
     },
     "popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
+      "version": "1.16.1-lts",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1-lts.tgz",
+      "integrity": "sha512-Kjw8nKRl1m+VrSFCoVGPph93W/qrSO7ZkqPpTf7F4bk/sqcfWK019dWBUpE/fBOsOQY1dks/Bmcbfn1heM/IsA=="
     },
     "portfinder": {
       "version": "1.0.28",
@@ -45207,8 +45213,7 @@
     "prettier": {
       "version": "2.8.4",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
-      "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
-      "dev": true
+      "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw=="
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",
@@ -45347,9 +45352,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "18.14.2",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.2.tgz",
-          "integrity": "sha512-1uEQxww3DaghA0RxqHx0O0ppVlo43pJhepY51OxuQIKHpjbnYLA7vcdwioNPzIqmC2u3I/dmylcqjlh0e7AyUA=="
+          "version": "18.15.0",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.0.tgz",
+          "integrity": "sha512-z6nr0TTEOBGkzLGmbypWOGnpSpSIBorEhC4L+4HeQ2iezKCi4f77kyslRwvHeNitymGQ+oFyIWGP96l/DPSV9w=="
         }
       }
     },
@@ -46743,11 +46748,11 @@
       }
     },
     "ripple-address-codec": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/ripple-address-codec/-/ripple-address-codec-4.2.4.tgz",
-      "integrity": "sha512-roAOjKz94+FboTItey1XRh5qynwt4xvfBLvbbcx+FiR94Yw2x3LrKLF2GVCMCSAh5I6PkcpADg6AbYsUbGN3nA==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/ripple-address-codec/-/ripple-address-codec-4.2.5.tgz",
+      "integrity": "sha512-SZ96zZH+0REeyEcYVFl0vqcsGRXiFXS2RUgHupHhtVkOEk6men53vngVjJwBrSnY+oa6Cri15q1zSni3DEoxNw==",
       "requires": {
-        "base-x": "3.0.9",
+        "base-x": "^3.0.9",
         "create-hash": "^1.1.2"
       },
       "dependencies": {
@@ -46762,16 +46767,16 @@
       }
     },
     "ripple-binary-codec": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/ripple-binary-codec/-/ripple-binary-codec-1.4.2.tgz",
-      "integrity": "sha512-EDKIyZMa/6Ay/oNgCwjD9b9CJv0zmBreeHVQeG4BYwy+9GPnIQjNeT5e/aB6OjAnhcmpgbPeBmzwmNVwzxlt0w==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/ripple-binary-codec/-/ripple-binary-codec-1.4.3.tgz",
+      "integrity": "sha512-P4ALjAJWBJpRApTQO+dJCrHE6mZxm7ypZot9OS0a3RCKOWTReNw0pDWfdhCGh1qXh71TeQnAk4CHdMLwR/76oQ==",
       "requires": {
         "assert": "^2.0.0",
         "big-integer": "^1.6.48",
         "buffer": "5.6.0",
         "create-hash": "^1.2.0",
         "decimal.js": "^10.2.0",
-        "ripple-address-codec": "^4.2.4"
+        "ripple-address-codec": "^4.2.5"
       },
       "dependencies": {
         "assert": {
@@ -46814,15 +46819,15 @@
       }
     },
     "ripple-keypairs": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/ripple-keypairs/-/ripple-keypairs-1.1.4.tgz",
-      "integrity": "sha512-PMMjTOxZmCSBOvHPj6bA+V/HGx7oFgDtGGI8VcZYuaFO2H87UX0X0jhfHy+LA2Xy31WYlD7GaDIDDt2QO+AMtw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ripple-keypairs/-/ripple-keypairs-1.1.5.tgz",
+      "integrity": "sha512-wLJXIBsMVazn2Yp/7oP4PvgA4Gd1HtuZLftdEJFNOLgraf82phqa2AnNK3t9f3XeQnApW1jAe/FcFFOY6QUn5w==",
       "requires": {
         "bn.js": "^5.1.1",
         "brorand": "^1.0.5",
         "elliptic": "^6.5.4",
         "hash.js": "^1.0.3",
-        "ripple-address-codec": "^4.2.4"
+        "ripple-address-codec": "^4.2.5"
       },
       "dependencies": {
         "bn.js": {
@@ -46833,9 +46838,9 @@
       }
     },
     "ripple-lib": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/ripple-lib/-/ripple-lib-1.10.0.tgz",
-      "integrity": "sha512-Cg2u73UybfM1PnzcuLt5flvLKZn35ovdIp+1eLrReVB4swuRuUF/SskJG9hf5wMosbvh+E+jZu8A6IbYJoyFIA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/ripple-lib/-/ripple-lib-1.10.1.tgz",
+      "integrity": "sha512-OQk+Syl2JfxKxV2KuF/kBMtnh012I5tNnziP3G4WDGCGSIAgeqkOgkR59IQ0YDNrs1YW8GbApxrdMSRi/QClcA==",
       "requires": {
         "@types/lodash": "^4.14.136",
         "@types/ws": "^7.2.0",
@@ -49070,9 +49075,8 @@
       }
     },
     "unchained-wallets": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/unchained-wallets/-/unchained-wallets-0.2.3.tgz",
-      "integrity": "sha512-o+Eh5lW+Vx0Za+R4nyxD2DBXcTO46SuPMWIco7c4BbRUEDIno9vIrIU+2ztCVkJ02N0+8o4GgcLWyibLYo1yvw==",
+      "version": "git+ssh://git@github.com/bucko13/unchained-wallets.git#2a96dc9eae7621a1c5b0a6cc8cd55cc94a338b1e",
+      "from": "unchained-wallets@bucko13/unchained-wallets#ledger-address-verification",
       "requires": {
         "@babel/polyfill": "^7.7.0",
         "@ledgerhq/hw-app-btc": "^5.34.1",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "redux-thunk": "^2.3.0",
     "reselect": "^4.0.0",
     "sass": "^1.56.2",
-    "unchained-bitcoin": "^0.3.0",
-    "unchained-wallets": "bucko13/unchained-wallets#ledger-address-verification"
+    "unchained-bitcoin": "^0.3.1",
+    "unchained-wallets": "^0.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "not op_mini all"
   ],
   "dependencies": {
-    "@material-ui/core": "^4.9.11",
+    "@material-ui/core": "^4.12.4",
     "@material-ui/icons": "^4.5.1",
     "@material-ui/lab": "^4.0.0-alpha.56",
     "axios": "^0.21.2",
@@ -121,6 +121,6 @@
     "reselect": "^4.0.0",
     "sass": "^1.56.2",
     "unchained-bitcoin": "^0.3.0",
-    "unchained-wallets": "^0.2.3"
+    "unchained-wallets": "bucko13/unchained-wallets#ledger-address-verification"
   }
 }

--- a/src/actions/walletActions.js
+++ b/src/actions/walletActions.js
@@ -27,6 +27,7 @@ export const RESET_WALLET = "RESET_WALLET";
 export const SPEND_SLICES = "SPEND_SLICES";
 export const INITIAL_LOAD_COMPLETE = "INITIAL_LOAD_COMPLETE";
 export const RESET_NODES_FETCH_ERRORS = "RESET_NODES_FETCH_ERRORS";
+export const UPDATE_POLICY_REGISTRATIONS = "UPDATE_POLICY_REGISTRATION";
 
 export const WALLET_MODES = {
   VIEW: 0,
@@ -302,6 +303,16 @@ export function updateWalletNameAction(number, value) {
   return {
     type: UPDATE_WALLET_NAME,
     value,
+  };
+}
+
+export function updateWalletPolicyRegistrationsAction({ xfp, policyHmac }) {
+  return {
+    type: UPDATE_POLICY_REGISTRATIONS,
+    value: {
+      xfp,
+      policyHmac,
+    },
   };
 }
 

--- a/src/components/RegisterWallet/DownloadColdcardConfig.jsx
+++ b/src/components/RegisterWallet/DownloadColdcardConfig.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useState } from "react";
 import { Button } from "@material-ui/core";
 import { useDispatch, useSelector } from "react-redux";
 import { COLDCARD, ConfigAdapter } from "unchained-wallets";
@@ -7,29 +7,17 @@ import { setErrorNotification } from "../../actions/errorNotificationActions";
 import { downloadFile } from "../../utils";
 
 const DownloadColdardConfigButton = ({ ...otherProps }) => {
-  const [disabledButton, setButtonDisabled] = useState(false);
+  const [isActive, setIsActive] = useState(false);
   const walletConfig = useSelector(getWalletConfig);
   const dispatch = useDispatch();
 
-  const interaction = useMemo(() => {
-    const hasXfps = walletConfig?.extendedPublicKeys?.every(
-      (xpub) => xpub?.xfp.length === 8
-    );
-    if (hasXfps)
-      return new ConfigAdapter({
-        KEYSTORE: COLDCARD,
-        jsonConfig: walletConfig,
-      });
-
-    // can't set the wallet config without xfps
-    // should setup to be masked in the future like
-    // with bip32 paths
-    setButtonDisabled(true);
-    return null;
-  }, [walletConfig]);
+  const interaction = new ConfigAdapter({
+    KEYSTORE: COLDCARD,
+    jsonConfig: walletConfig,
+  });
 
   const downloadWalletDetails = () => {
-    setButtonDisabled(true);
+    setIsActive(true);
     try {
       const { startingAddressIndex } = walletConfig;
       // If this is a config that's been rekeyed, note that in the name.
@@ -51,7 +39,7 @@ const DownloadColdardConfigButton = ({ ...otherProps }) => {
     } catch (e) {
       dispatch(setErrorNotification(e.message || e));
     } finally {
-      setButtonDisabled(false);
+      setIsActive(false);
     }
   };
 
@@ -59,7 +47,7 @@ const DownloadColdardConfigButton = ({ ...otherProps }) => {
     <Button
       variant="outlined"
       onClick={downloadWalletDetails}
-      disabled={disabledButton}
+      disabled={isActive}
       {...otherProps}
     >
       Download Coldcard Config

--- a/src/components/RegisterWallet/DownloadColdcardConfig.jsx
+++ b/src/components/RegisterWallet/DownloadColdcardConfig.jsx
@@ -1,0 +1,58 @@
+import React, { useState } from "react";
+import { Button } from "@material-ui/core";
+import { useDispatch, useSelector } from "react-redux";
+import { COLDCARD, ConfigAdapter } from "unchained-wallets";
+import { getWalletConfig } from "../../selectors/wallet";
+import { setErrorNotification } from "../../actions/errorNotificationActions";
+import { downloadFile } from "../../utils";
+
+const DownloadColdardConfigButton = ({ ...otherProps }) => {
+  const [isActive, setIsActive] = useState(false);
+  const walletConfig = useSelector(getWalletConfig);
+  const dispatch = useDispatch();
+
+  const interaction = new ConfigAdapter({
+    KEYSTORE: COLDCARD,
+    jsonConfig: walletConfig,
+  });
+
+  const downloadWalletDetails = () => {
+    setIsActive(true);
+    try {
+      const { startingAddressIndex } = walletConfig;
+      // If this is a config that's been rekeyed, note that in the name.
+      walletConfig.name =
+        startingAddressIndex === 0
+          ? walletConfig.name
+          : `${walletConfig.name}_${startingAddressIndex.toString()}`;
+
+      // At the moment (2020-Dec), Coldcard has just released a new firmware version
+      // which addresses the following problem:  that they inverted the ordering
+      // for p2sh-p2wsh as p2wsh-p2sh but we need to support the older firmware.
+      walletConfig.addressType = walletConfig.addressType.includes("-")
+        ? "P2WSH-P2SH"
+        : walletConfig.addressType;
+
+      const body = interaction.adapt();
+      const filename = `wc-${walletConfig.name}.txt`;
+      downloadFile(body, filename);
+    } catch (e) {
+      dispatch(setErrorNotification(e.message || e));
+    } finally {
+      setIsActive(false);
+    }
+  };
+
+  return (
+    <Button
+      variant="outlined"
+      onClick={downloadWalletDetails}
+      disabled={isActive}
+      {...otherProps}
+    >
+      Download Coldcard Config
+    </Button>
+  );
+};
+
+export default DownloadColdardConfigButton;

--- a/src/components/RegisterWallet/PolicyRegistrationsTable.jsx
+++ b/src/components/RegisterWallet/PolicyRegistrationsTable.jsx
@@ -1,0 +1,69 @@
+import React, { useMemo } from "react";
+import PropTypes from "prop-types";
+import {
+  Box,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@material-ui/core";
+import { useSelector } from "react-redux";
+
+const PolicyRegistrationTable = ({ hmacs }) => {
+  const extendedPublicKeyImporters = useSelector(
+    (state) => state.quorum.extendedPublicKeyImporters
+  );
+
+  const hmacsWithName = useMemo(() => {
+    return Object.values(extendedPublicKeyImporters)
+      .map((importer) => {
+        const policyHmac = hmacs.find(
+          (hmac) => hmac.xfp === importer.rootXfp
+        )?.policyHmac;
+        return { policyHmac, name: importer.name };
+      })
+      .filter((registration) => registration.policyHmac);
+  }, [hmacs, extendedPublicKeyImporters]);
+
+  if (!hmacs) {
+    return (
+      <Typography>
+        (No ledger registrations have been saved with this wallet)
+      </Typography>
+    );
+  }
+
+  return (
+    <Box>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>Name</TableCell>
+            <TableCell>Device</TableCell>
+            <TableCell>Registration</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {hmacsWithName.map(({ name, policyHmac }) => (
+            <TableRow key={policyHmac}>
+              <TableCell>{name}</TableCell>
+              {/* Note that only ledgers currently support this registration type */}
+              <TableCell>Ledger</TableCell>
+              <TableCell>{policyHmac}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </Box>
+  );
+};
+
+PolicyRegistrationTable.propTypes = {
+  hmacs: PropTypes.arrayOf(
+    PropTypes.shape({ xfp: PropTypes.string, policyHmac: PropTypes.string })
+  ).isRequired,
+};
+
+export default PolicyRegistrationTable;

--- a/src/components/RegisterWallet/PolicyRegistrationsTable.jsx
+++ b/src/components/RegisterWallet/PolicyRegistrationsTable.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import {
   Box,
@@ -10,22 +10,10 @@ import {
   Typography,
 } from "@material-ui/core";
 import { useSelector } from "react-redux";
+import { getHmacsWithName } from "../../selectors/wallet";
 
 const PolicyRegistrationTable = ({ hmacs }) => {
-  const extendedPublicKeyImporters = useSelector(
-    (state) => state.quorum.extendedPublicKeyImporters
-  );
-
-  const hmacsWithName = useMemo(() => {
-    return Object.values(extendedPublicKeyImporters)
-      .map((importer) => {
-        const policyHmac = hmacs.find(
-          (hmac) => hmac.xfp === importer.rootXfp
-        )?.policyHmac;
-        return { policyHmac, name: importer.name };
-      })
-      .filter((registration) => registration.policyHmac);
-  }, [hmacs, extendedPublicKeyImporters]);
+  const hmacsWithName = useSelector(getHmacsWithName);
 
   if (!hmacs) {
     return (

--- a/src/components/RegisterWallet/RegisterLedgerButton.jsx
+++ b/src/components/RegisterWallet/RegisterLedgerButton.jsx
@@ -1,0 +1,42 @@
+import React, { useState } from "react";
+import { Button } from "@material-ui/core";
+import { useDispatch, useSelector } from "react-redux";
+import { LEDGER, RegisterWalletPolicy } from "unchained-wallets";
+import { getWalletConfig } from "../../selectors/wallet";
+import { updateWalletPolicyRegistrationsAction } from "../../actions/walletActions";
+import { setErrorNotification } from "../../actions/errorNotificationActions";
+
+const RegisterLedgerButton = ({ ...otherProps }) => {
+  const [isActive, setIsActive] = useState(false);
+  const walletConfig = useSelector(getWalletConfig);
+  const dispatch = useDispatch();
+
+  const registerWallet = async () => {
+    setIsActive(true);
+    try {
+      const interaction = new RegisterWalletPolicy({
+        keystore: LEDGER,
+        ...walletConfig,
+      });
+      const xfp = await interaction.getXfp();
+      const policyHmac = await interaction.run();
+      dispatch(updateWalletPolicyRegistrationsAction({ xfp, policyHmac }));
+    } catch (e) {
+      dispatch(setErrorNotification(e.message));
+    } finally {
+      setIsActive(false);
+    }
+  };
+  return (
+    <Button
+      variant="outlined"
+      onClick={registerWallet}
+      disabled={isActive}
+      {...otherProps}
+    >
+      Register w/ Ledger
+    </Button>
+  );
+};
+
+export default RegisterLedgerButton;

--- a/src/components/RegisterWallet/index.jsx
+++ b/src/components/RegisterWallet/index.jsx
@@ -1,0 +1,9 @@
+import DownloadColdardConfigButton from "./DownloadColdcardConfig";
+import PolicyRegistrationTable from "./PolicyRegistrationsTable";
+import RegisterLedgerButton from "./RegisterLedgerButton";
+
+export {
+  DownloadColdardConfigButton,
+  PolicyRegistrationTable,
+  RegisterLedgerButton,
+};

--- a/src/components/ScriptExplorer/DirectSignatureImporter.jsx
+++ b/src/components/ScriptExplorer/DirectSignatureImporter.jsx
@@ -21,6 +21,7 @@ import {
   TableCell,
 } from "@material-ui/core";
 import InteractionMessages from "../InteractionMessages";
+import { walletConfigPropType } from "../../proptypes/wallet";
 
 class DirectSignatureImporter extends React.Component {
   constructor(props) {
@@ -51,11 +52,9 @@ class DirectSignatureImporter extends React.Component {
         return signatureImporter.bip32Path; // pubkey path
       return `${signatureImporter.bip32Path}${input.bip32Path.slice(1)}`; // xpub/pubkey slice away the m, keep /
     });
-    const policyHmac =
-      // eslint-disable-next-line react/prop-types
-      walletConfig.ledgerPolicyHmacs.find(
-        (hmac) => hmac.xfp === extendedPublicKeyImporter.rootXfp
-      )?.policyHmac;
+    const policyHmac = walletConfig.ledgerPolicyHmacs.find(
+      (hmac) => hmac.xfp === extendedPublicKeyImporter.rootXfp
+    )?.policyHmac;
 
     return SignMultisigTransaction({
       network,
@@ -297,8 +296,7 @@ DirectSignatureImporter.propTypes = {
     method: PropTypes.string,
   }).isRequired,
   signatureImporters: PropTypes.shape({}).isRequired,
-  // eslint-disable-next-line react/forbid-prop-types
-  walletConfig: PropTypes.object.isRequired,
+  walletConfig: PropTypes.shape(walletConfigPropType).isRequired,
   validateAndSetBIP32Path: PropTypes.func.isRequired,
   validateAndSetSignature: PropTypes.func.isRequired,
 };

--- a/src/components/ScriptExplorer/DirectSignatureImporter.jsx
+++ b/src/components/ScriptExplorer/DirectSignatureImporter.jsx
@@ -37,14 +37,26 @@ class DirectSignatureImporter extends React.Component {
   };
 
   interaction = () => {
-    const { signatureImporter, network, inputs, outputs, walletConfig } =
-      this.props;
+    const {
+      signatureImporter,
+      network,
+      inputs,
+      outputs,
+      walletConfig,
+      extendedPublicKeyImporter,
+    } = this.props;
     const keystore = signatureImporter.method;
     const bip32Paths = inputs.map((input) => {
       if (typeof input.bip32Path === "undefined")
         return signatureImporter.bip32Path; // pubkey path
       return `${signatureImporter.bip32Path}${input.bip32Path.slice(1)}`; // xpub/pubkey slice away the m, keep /
     });
+    const policyHmac =
+      // eslint-disable-next-line react/prop-types
+      walletConfig.ledgerPolicyHmacs.find(
+        (hmac) => hmac.xfp === extendedPublicKeyImporter.rootXfp
+      )?.policyHmac;
+
     return SignMultisigTransaction({
       network,
       keystore,
@@ -52,6 +64,7 @@ class DirectSignatureImporter extends React.Component {
       outputs,
       bip32Paths,
       walletConfig,
+      policyHmac,
       returnSignatureArray: true,
     });
   };
@@ -270,6 +283,7 @@ DirectSignatureImporter.propTypes = {
   enableChangeMethod: PropTypes.func.isRequired,
   extendedPublicKeyImporter: PropTypes.shape({
     method: PropTypes.string,
+    rootXfp: PropTypes.string,
   }).isRequired,
   fee: PropTypes.string.isRequired,
   inputsTotalSats: PropTypes.shape({}).isRequired,

--- a/src/components/ScriptExplorer/SignatureImporter.jsx
+++ b/src/components/ScriptExplorer/SignatureImporter.jsx
@@ -144,6 +144,7 @@ class SignatureImporter extends React.Component {
       requiredSigners,
       addressType,
       walletName,
+      ledgerPolicyHmacs,
     } = this.props;
     const { method } = signatureImporter;
 
@@ -171,6 +172,7 @@ class SignatureImporter extends React.Component {
             quorum: { requiredSigners },
             extendedPublicKeys,
             name: walletName,
+            ledgerPolicyHmacs,
           }}
         />
       );
@@ -584,6 +586,8 @@ SignatureImporter.propTypes = {
   unsignedTransaction: PropTypes.shape({}).isRequired,
   setSigningKey: PropTypes.func.isRequired,
   walletName: PropTypes.string.isRequired,
+  // eslint-disable-next-line react/forbid-prop-types
+  ledgerPolicyHmacs: PropTypes.array.isRequired,
 };
 
 SignatureImporter.defaultProps = {
@@ -601,6 +605,7 @@ function mapStateToProps(state, ownProps) {
     },
     ...state.spend.transaction,
     requiredSigners: state.settings.requiredSigners,
+    ledgerPolicyHmacs: state.wallet.common.ledgerPolicyHmacs,
     extendedPublicKeys: Object.values(
       state.quorum.extendedPublicKeyImporters
     ).map((key) => ({

--- a/src/components/Slices/ConfirmAddress.jsx
+++ b/src/components/Slices/ConfirmAddress.jsx
@@ -146,7 +146,7 @@ const ConfirmAddress = ({ slice, network }) => {
             bip32Path: fullBip32Path,
             multisig,
             walletConfig,
-            policyHmac: state.ledgerPolicyHmac,
+            policyHmac: ledgerPolicyHmac,
           })
         );
         dispatch({ type: "HAS_INTERACTION", value: true });

--- a/src/components/Slices/ConfirmAddress.jsx
+++ b/src/components/Slices/ConfirmAddress.jsx
@@ -34,6 +34,7 @@ import ExtendedPublicKeySelector from "../Wallet/ExtendedPublicKeySelector";
 import InteractionMessages from "../InteractionMessages";
 
 import { slicePropTypes } from "../../proptypes";
+import { walletConfigPropType } from "../../proptypes/wallet";
 
 const TEXT = "text";
 
@@ -314,8 +315,7 @@ const ConfirmAddress = ({ slice, network, walletConfig }) => {
 ConfirmAddress.propTypes = {
   slice: PropTypes.shape(slicePropTypes).isRequired,
   network: PropTypes.string,
-  // eslint-disable-next-line react/forbid-prop-types
-  walletConfig: PropTypes.object.isRequired,
+  walletConfig: PropTypes.shape(walletConfigPropType).isRequired,
 };
 
 ConfirmAddress.defaultProps = {

--- a/src/components/Slices/ConfirmAddress.jsx
+++ b/src/components/Slices/ConfirmAddress.jsx
@@ -30,11 +30,12 @@ import {
   ConfirmMultisigAddress,
 } from "unchained-wallets";
 
+import { useSelector } from "react-redux";
 import ExtendedPublicKeySelector from "../Wallet/ExtendedPublicKeySelector";
 import InteractionMessages from "../InteractionMessages";
 
 import { slicePropTypes } from "../../proptypes";
-import { walletConfigPropType } from "../../proptypes/wallet";
+import { getWalletConfig } from "../../selectors/wallet";
 
 const TEXT = "text";
 
@@ -88,7 +89,8 @@ const interactionReducer = (state, action) => {
   }
 };
 
-const ConfirmAddress = ({ slice, network, walletConfig }) => {
+const ConfirmAddress = ({ slice, network }) => {
+  const walletConfig = useSelector(getWalletConfig);
   const [state, dispatch] = useReducer(
     interactionReducer,
     initialInteractionState
@@ -315,7 +317,6 @@ const ConfirmAddress = ({ slice, network, walletConfig }) => {
 ConfirmAddress.propTypes = {
   slice: PropTypes.shape(slicePropTypes).isRequired,
   network: PropTypes.string,
-  walletConfig: PropTypes.shape(walletConfigPropType).isRequired,
 };
 
 ConfirmAddress.defaultProps = {

--- a/src/components/Slices/SliceDetails.jsx
+++ b/src/components/Slices/SliceDetails.jsx
@@ -11,6 +11,7 @@ import {
   AppBar,
   makeStyles,
 } from "@material-ui/core";
+import { useSelector } from "react-redux";
 
 import UTXOSet from "../ScriptExplorer/UTXOSet";
 import MultisigDetails from "../MultisigDetails";
@@ -18,6 +19,7 @@ import ImportAddressesButton from "../ImportAddressesButton";
 import ConfirmAddress from "./ConfirmAddress";
 
 import { slicePropTypes, clientPropTypes } from "../../proptypes";
+import { getWalletConfig } from "../../selectors/wallet";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -73,6 +75,7 @@ TabPanel.defaultProps = {
 
 const SliceDetails = ({ slice, client, network }) => {
   const [tabIndex, setTabIndex] = React.useState("0");
+  const walletConfig = useSelector(getWalletConfig);
   const classes = useStyles();
 
   const handleChange = (_e, newIndex) => setTabIndex(newIndex);
@@ -95,7 +98,11 @@ const SliceDetails = ({ slice, client, network }) => {
           <Typography variant="caption">
             (not all device variants supported)
           </Typography>
-          <ConfirmAddress slice={slice} network={network} />
+          <ConfirmAddress
+            slice={slice}
+            network={network}
+            walletConfig={walletConfig}
+          />
         </div>
       ),
     },

--- a/src/components/Slices/SliceDetails.jsx
+++ b/src/components/Slices/SliceDetails.jsx
@@ -11,7 +11,6 @@ import {
   AppBar,
   makeStyles,
 } from "@material-ui/core";
-import { useSelector } from "react-redux";
 
 import UTXOSet from "../ScriptExplorer/UTXOSet";
 import MultisigDetails from "../MultisigDetails";
@@ -19,7 +18,6 @@ import ImportAddressesButton from "../ImportAddressesButton";
 import ConfirmAddress from "./ConfirmAddress";
 
 import { slicePropTypes, clientPropTypes } from "../../proptypes";
-import { getWalletConfig } from "../../selectors/wallet";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -75,7 +73,6 @@ TabPanel.defaultProps = {
 
 const SliceDetails = ({ slice, client, network }) => {
   const [tabIndex, setTabIndex] = React.useState("0");
-  const walletConfig = useSelector(getWalletConfig);
   const classes = useStyles();
 
   const handleChange = (_e, newIndex) => setTabIndex(newIndex);
@@ -98,11 +95,7 @@ const SliceDetails = ({ slice, client, network }) => {
           <Typography variant="caption">
             (not all device variants supported)
           </Typography>
-          <ConfirmAddress
-            slice={slice}
-            network={network}
-            walletConfig={walletConfig}
-          />
+          <ConfirmAddress slice={slice} network={network} />
         </div>
       ),
     },

--- a/src/components/Wallet/ConfirmWallet.jsx
+++ b/src/components/Wallet/ConfirmWallet.jsx
@@ -37,16 +37,16 @@ const PolicyInfo = ({ keys }) => {
     (state) => state.quorum.extendedPublicKeyImporters
   );
 
-  const keyOriginsWithName = Object.values(extendedPublicKeyImporters).map(
-    (importer) => {
+  const keyOriginsWithName = useMemo(() => {
+    return Object.values(extendedPublicKeyImporters).map((importer) => {
       const origin = keys.find(
         (key) =>
           key.includes(importer.rootXfp) &&
           key.includes(importer.extendedPublicKey)
       );
       return { origin, name: importer.name };
-    }
-  );
+    });
+  }, [extendedPublicKeyImporters, keys]);
 
   return (
     <>

--- a/src/components/Wallet/ConfirmWallet.jsx
+++ b/src/components/Wallet/ConfirmWallet.jsx
@@ -1,6 +1,6 @@
-import React from "react";
+import React, { useMemo } from "react";
 import PropTypes from "prop-types";
-import { connect } from "react-redux";
+import { useSelector } from "react-redux";
 import {
   Table,
   TableHead,
@@ -9,58 +9,122 @@ import {
   TableCell,
   Box,
 } from "@material-ui/core";
-import { Alert } from "@material-ui/lab";
+import { Alert, AlertTitle } from "@material-ui/lab";
+import { MultisigWalletPolicy } from "unchained-wallets";
+import { getWalletConfig } from "../../selectors/wallet";
 
-class WalletConfirmation extends React.Component {
-  render = () => {
-    const { startingAddressIndex } = this.props;
+const ConfirmationInfo = () => {
+  const extendedPublicKeyImporters = useSelector(
+    (state) => state.quorum.extendedPublicKeyImporters
+  );
+  return (
+    <>
+      {Object.values(extendedPublicKeyImporters).map((importer) => (
+        <TableRow key={importer.extendedPublicKey}>
+          <TableCell>{importer.name}</TableCell>
+          <TableCell>
+            {importer.method === "text" ? "N/A" : importer.bip32Path}
+          </TableCell>
+          <TableCell>{importer.extendedPublicKey}</TableCell>
+        </TableRow>
+      ))}
+    </>
+  );
+};
+
+const PolicyInfo = ({ keys }) => {
+  const extendedPublicKeyImporters = useSelector(
+    (state) => state.quorum.extendedPublicKeyImporters
+  );
+
+  const keyOriginsWithName = Object.values(extendedPublicKeyImporters).map(
+    (importer) => {
+      const origin = keys.find(
+        (key) =>
+          key.includes(importer.rootXfp) &&
+          key.includes(importer.extendedPublicKey)
+      );
+      return { origin, name: importer.name };
+    }
+  );
+
+  return (
+    <>
+      {keyOriginsWithName.map(({ origin, name }) => (
+        <TableRow key={origin}>
+          <TableCell>{name}</TableCell>
+          <TableCell>{origin}</TableCell>
+        </TableRow>
+      ))}
+    </>
+  );
+};
+
+PolicyInfo.propTypes = {
+  keys: PropTypes.arrayOf(PropTypes.string).isRequired,
+};
+
+const WalletConfirmation = () => {
+  const startingAddressIndex = useSelector(
+    (state) => state.settings.startingAddressIndex
+  );
+  const walletConfig = useSelector(getWalletConfig);
+
+  const policy = useMemo(() => {
+    // there could be edge cases where not all
+    // info from config matches what we need for a policy
+    try {
+      return MultisigWalletPolicy.FromWalletConfig(walletConfig);
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error(e);
+      return null;
+    }
+  }, [walletConfig]);
+
+  if (policy)
     return (
       <Box>
-        {startingAddressIndex > 0 && (
-          <Alert severity="info">
-            Starting Address Index set to {startingAddressIndex}
-          </Alert>
-        )}
         <Table>
           <TableHead>
             <TableRow>
               <TableCell>Name</TableCell>
-              <TableCell>BIP32 Path</TableCell>
-              <TableCell>Extended Public Key</TableCell>
+              <TableCell>Key Origin</TableCell>
             </TableRow>
           </TableHead>
-          <TableBody>{this.renderConfirmationInfo()}</TableBody>
+          <TableBody>
+            <PolicyInfo keys={policy.keys} />
+          </TableBody>
         </Table>
+        <Box my={3}>
+          <Alert severity="info">
+            <AlertTitle>Wallet Policy Details</AlertTitle>
+            Policy template: <code>{policy.template}</code>
+          </Alert>
+        </Box>
       </Box>
     );
-  };
-
-  renderConfirmationInfo = () => {
-    const { extendedPublicKeyImporters } = this.props;
-    return Object.values(extendedPublicKeyImporters).map((importer) => (
-      <TableRow key={importer.extendedPublicKey}>
-        <TableCell>{importer.name}</TableCell>
-        <TableCell>
-          {importer.method === "text" ? "N/A" : importer.bip32Path}
-        </TableCell>
-        <TableCell>{importer.extendedPublicKey}</TableCell>
-      </TableRow>
-    ));
-  };
-}
-
-WalletConfirmation.propTypes = {
-  startingAddressIndex: PropTypes.number.isRequired,
-  extendedPublicKeyImporters: PropTypes.shape({}).isRequired,
+  return (
+    <Box>
+      {startingAddressIndex > 0 && (
+        <Alert severity="info">
+          Starting Address Index set to {startingAddressIndex}
+        </Alert>
+      )}
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>Name</TableCell>
+            <TableCell>BIP32 Path</TableCell>
+            <TableCell>Extended Public Key</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          <ConfirmationInfo />
+        </TableBody>
+      </Table>
+    </Box>
+  );
 };
 
-function mapStateToProps(state) {
-  return {
-    startingAddressIndex: state.settings.startingAddressIndex,
-    extendedPublicKeyImporters: state.quorum.extendedPublicKeyImporters,
-  };
-}
-
-const mapDispatchToProps = {};
-
-export default connect(mapStateToProps, mapDispatchToProps)(WalletConfirmation);
+export default WalletConfirmation;

--- a/src/components/Wallet/ConfirmWallet.jsx
+++ b/src/components/Wallet/ConfirmWallet.jsx
@@ -9,7 +9,7 @@ import {
   TableCell,
   Box,
 } from "@material-ui/core";
-import { Alert, AlertTitle } from "@material-ui/lab";
+import { Alert } from "@material-ui/lab";
 import { MultisigWalletPolicy } from "unchained-wallets";
 import { getWalletConfig } from "../../selectors/wallet";
 
@@ -96,12 +96,6 @@ const WalletConfirmation = () => {
             <PolicyInfo keys={policy.keys} />
           </TableBody>
         </Table>
-        <Box my={3}>
-          <Alert severity="info">
-            <AlertTitle>Wallet Policy Details</AlertTitle>
-            Policy template: <code>{policy.template}</code>
-          </Alert>
-        </Box>
       </Box>
     );
   return (

--- a/src/components/Wallet/RegisterWallet.jsx
+++ b/src/components/Wallet/RegisterWallet.jsx
@@ -46,12 +46,14 @@ const WalletRegistrations = () => {
         >
           <Box>
             <Typography variant="h5">Wallet Registration</Typography>
-            <Box my={1}>
-              <Alert severity="info">
-                <AlertTitle>Wallet Policy Details</AlertTitle>
-                Policy template: <code>{policy.template}</code>
-              </Alert>
-            </Box>
+            {policy?.template && (
+              <Box my={1}>
+                <Alert severity="info">
+                  <AlertTitle>Wallet Policy Details</AlertTitle>
+                  Policy template: <code>{policy.template}</code>
+                </Alert>
+              </Box>
+            )}
             <Typography variant="caption">
               Some devices allow a multisig wallet to be registered in order to
               verify addresses and transactions

--- a/src/components/Wallet/RegisterWallet.jsx
+++ b/src/components/Wallet/RegisterWallet.jsx
@@ -35,6 +35,24 @@ const WalletRegistrations = () => {
       return null;
     }
   }, [walletConfig]);
+
+  const missingXfps = useMemo(() => {
+    if (!walletConfig?.extendedPublicKeys) return false;
+    return !walletConfig.extendedPublicKeys.every(
+      (xpub) => xpub?.xfp.length === 8
+    );
+  }, [walletConfig]);
+
+  // should setup to be masked in the future like
+  // with bip32 paths
+  if (missingXfps)
+    return (
+      <Typography color="error">
+        Wallet configuration missing root fingerprints (also known as an xfp).
+        Some devices will be unable to sign.
+      </Typography>
+    );
+
   return (
     <Box my={2}>
       <Accordion>

--- a/src/components/Wallet/RegisterWallet.jsx
+++ b/src/components/Wallet/RegisterWallet.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import {
   Box,
   Grid,
@@ -11,6 +11,8 @@ import {
 import { useSelector } from "react-redux";
 
 import { ExpandMoreOutlined } from "@material-ui/icons";
+import { MultisigWalletPolicy } from "unchained-wallets/lib/policy";
+import { Alert, AlertTitle } from "@material-ui/lab";
 import { getWalletConfig } from "../../selectors/wallet";
 import PolicyRegistrationTable from "../RegisterWallet/PolicyRegistrationsTable";
 import {
@@ -22,8 +24,19 @@ const useStyles = makeStyles({ expanded: { margin: "0 0!important" } });
 const WalletRegistrations = () => {
   const walletConfig = useSelector(getWalletConfig);
   const classes = useStyles();
+  const policy = useMemo(() => {
+    // there could be edge cases where not all
+    // info from config matches what we need for a policy
+    try {
+      return MultisigWalletPolicy.FromWalletConfig(walletConfig);
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error(e);
+      return null;
+    }
+  }, [walletConfig]);
   return (
-    <Box mt={3}>
+    <Box my={2}>
       <Accordion>
         <AccordionSummary
           expandIcon={<ExpandMoreOutlined />}
@@ -33,9 +46,15 @@ const WalletRegistrations = () => {
         >
           <Box>
             <Typography variant="h5">Wallet Registration</Typography>
+            <Box my={1}>
+              <Alert severity="info">
+                <AlertTitle>Wallet Policy Details</AlertTitle>
+                Policy template: <code>{policy.template}</code>
+              </Alert>
+            </Box>
             <Typography variant="caption">
-              Some devices allow a multisig wallet to be pre-registered in order
-              to verify addresses and transactions
+              Some devices allow a multisig wallet to be registered in order to
+              verify addresses and transactions
             </Typography>
           </Box>
         </AccordionSummary>

--- a/src/components/Wallet/RegisterWallet.jsx
+++ b/src/components/Wallet/RegisterWallet.jsx
@@ -68,7 +68,15 @@ const WalletRegistrations = () => {
                 <DownloadColdardConfigButton />
               </Grid>
             </Grid>
-            <PolicyRegistrationTable hmacs={walletConfig.ledgerPolicyHmacs} />
+            {walletConfig.ledgerPolicyHmacs.length ? (
+              <PolicyRegistrationTable hmacs={walletConfig.ledgerPolicyHmacs} />
+            ) : (
+              <Box my={1}>
+                <Typography variant="body2">
+                  (No known registrations available.)
+                </Typography>
+              </Box>
+            )}
           </Box>
         </AccordionDetails>
       </Accordion>

--- a/src/components/Wallet/RegisterWallet.jsx
+++ b/src/components/Wallet/RegisterWallet.jsx
@@ -1,0 +1,60 @@
+import React from "react";
+import {
+  Box,
+  Grid,
+  Typography,
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  makeStyles,
+} from "@material-ui/core";
+import { useSelector } from "react-redux";
+
+import { ExpandMoreOutlined } from "@material-ui/icons";
+import { getWalletConfig } from "../../selectors/wallet";
+import PolicyRegistrationTable from "../RegisterWallet/PolicyRegistrationsTable";
+import {
+  DownloadColdardConfigButton,
+  RegisterLedgerButton,
+} from "../RegisterWallet";
+
+const useStyles = makeStyles({ expanded: { margin: "0 0!important" } });
+const WalletRegistrations = () => {
+  const walletConfig = useSelector(getWalletConfig);
+  const classes = useStyles();
+  return (
+    <Box mt={3}>
+      <Accordion>
+        <AccordionSummary
+          expandIcon={<ExpandMoreOutlined />}
+          aria-controls="wallet-registration-content"
+          id="wallet-registration-header"
+          classes={{ expanded: classes.expanded }}
+        >
+          <Box>
+            <Typography variant="h5">Wallet Registration</Typography>
+            <Typography variant="caption">
+              Some devices allow a multisig wallet to be pre-registered in order
+              to verify addresses and transactions
+            </Typography>
+          </Box>
+        </AccordionSummary>
+        <AccordionDetails>
+          <Box>
+            <Grid container spacing={2}>
+              <Grid item>
+                <RegisterLedgerButton />
+              </Grid>
+              <Grid item>
+                <DownloadColdardConfigButton />
+              </Grid>
+            </Grid>
+            <PolicyRegistrationTable hmacs={walletConfig.ledgerPolicyHmacs} />
+          </Box>
+        </AccordionDetails>
+      </Accordion>
+    </Box>
+  );
+};
+
+export default WalletRegistrations;

--- a/src/components/Wallet/RegisterWallet.jsx
+++ b/src/components/Wallet/RegisterWallet.jsx
@@ -49,7 +49,8 @@ const WalletRegistrations = () => {
     return (
       <Typography color="error">
         Wallet configuration missing root fingerprints (also known as an xfp).
-        Some devices will be unable to sign.
+        Some devices will be unable to sign until all keys are used to rebuild
+        the multisig wallet.
       </Typography>
     );
 

--- a/src/components/Wallet/WalletGenerator.jsx
+++ b/src/components/Wallet/WalletGenerator.jsx
@@ -20,7 +20,6 @@ import {
   Box,
 } from "@material-ui/core";
 import AccountCircleIcon from "@material-ui/icons/AccountCircle";
-import { RegisterWalletPolicy, LEDGER_V2 } from "unchained-wallets";
 import {
   fetchAddressUTXOs,
   getAddressStatus,
@@ -28,6 +27,7 @@ import {
 } from "../../blockchain";
 import ClientPicker from "../ClientPicker";
 import ConfirmWallet from "./ConfirmWallet";
+import RegisterWallet from "./RegisterWallet";
 import WalletControl from "./WalletControl";
 import WalletConfigInteractionButtons from "./WalletConfigInteractionButtons";
 import { setFrozen } from "../../actions/settingsActions";
@@ -48,9 +48,6 @@ import {
   SET_CLIENT_PASSWORD_ERROR,
 } from "../../actions/clientActions";
 import { MAX_FETCH_UTXOS_ERRORS, MAX_TRAILING_EMPTY_NODES } from "./constants";
-import { getWalletDetailsText } from "../../selectors/wallet";
-
-// const bitcoin = require('bitcoinjs-lib');
 
 class WalletGenerator extends React.Component {
   constructor(props) {
@@ -347,19 +344,6 @@ class WalletGenerator extends React.Component {
     });
   }
 
-  async registerWallet() {
-    const { walletConfig, updateWalletPolicyRegistrations } = this.props;
-
-    const interaction = new RegisterWalletPolicy({
-      keystore: LEDGER_V2,
-      returnXfp: true,
-      ...JSON.parse(walletConfig),
-    });
-
-    const { xfp, policyHmac } = await interaction.run();
-    updateWalletPolicyRegistrations({ xfp, policyHmac });
-  }
-
   body() {
     const {
       totalSigners,
@@ -397,13 +381,11 @@ class WalletGenerator extends React.Component {
                 onClearFn={(e) => this.toggleImporters(e, true)}
                 onDownloadFn={downloadWalletDetails}
               />
-              <Button
-                variant="contained"
-                color="secondary"
-                onClick={() => this.registerWallet()}
-              >
-                Register Wallet (Ledger only)
-              </Button>
+              <Grid container>
+                <Grid item>
+                  <RegisterWallet />
+                </Grid>
+              </Grid>
               {unknownClient && (
                 <Box my={5}>
                   <Typography variant="subtitle1">
@@ -541,8 +523,6 @@ WalletGenerator.propTypes = {
   totalSigners: PropTypes.number.isRequired,
   updateChangeSlice: PropTypes.func.isRequired,
   updateDepositSlice: PropTypes.func.isRequired,
-  walletConfig: PropTypes.string.isRequired,
-  updateWalletPolicyRegistrations: PropTypes.func.isRequired,
 };
 
 function mapStateToProps(state) {
@@ -552,7 +532,6 @@ function mapStateToProps(state) {
     ...state.quorum,
     ...state.wallet,
     ...state.wallet.common,
-    walletConfig: getWalletDetailsText(state),
   };
 }
 

--- a/src/components/Wallet/WalletGenerator.jsx
+++ b/src/components/Wallet/WalletGenerator.jsx
@@ -372,6 +372,11 @@ class WalletGenerator extends React.Component {
                 {configuring ? "Hide Key Selection" : "Edit Details"}
               </Button>
               <ConfirmWallet />
+              <Grid container>
+                <Grid item>
+                  <RegisterWallet />
+                </Grid>
+              </Grid>
               <p>
                 You have imported all&nbsp;
                 {totalSigners} extended public keys. You will need to save this
@@ -381,11 +386,6 @@ class WalletGenerator extends React.Component {
                 onClearFn={(e) => this.toggleImporters(e, true)}
                 onDownloadFn={downloadWalletDetails}
               />
-              <Grid container>
-                <Grid item>
-                  <RegisterWallet />
-                </Grid>
-              </Grid>
               {unknownClient && (
                 <Box my={5}>
                   <Typography variant="subtitle1">

--- a/src/components/Wallet/index.jsx
+++ b/src/components/Wallet/index.jsx
@@ -323,9 +323,14 @@ class CreateWallet extends React.Component {
         setExtendedPublicKeyImporterFinalized(number, true);
       }
     );
-    walletConfiguration.ledgerPolicyHmacs.forEach(
-      updateWalletPolicyRegistrations
-    );
+
+    // config might not have this field at all, so need to account for it
+    // being empty
+    if (walletConfiguration.ledgerPolicyHmacs) {
+      walletConfiguration.ledgerPolicyHmacs.forEach(
+        updateWalletPolicyRegistrations
+      );
+    }
   };
 
   // add client picker if client === 'unknown'

--- a/src/components/Wallet/index.jsx
+++ b/src/components/Wallet/index.jsx
@@ -14,6 +14,7 @@ import {
   updateChangeSliceAction,
   updateDepositSliceAction,
   updateWalletNameAction as updateWalletNameActionImport,
+  updateWalletPolicyRegistrationsAction,
 } from "../../actions/walletActions";
 import { fetchSliceData as fetchSliceDataAction } from "../../actions/braidActions";
 import walletSelectors from "../../selectors";
@@ -262,6 +263,7 @@ class CreateWallet extends React.Component {
       setClientType,
       setClientUrl,
       setClientUsername,
+      updateWalletPolicyRegistrations,
     } = this.props;
 
     const walletConfiguration = JSON.parse(configJson);
@@ -320,6 +322,9 @@ class CreateWallet extends React.Component {
 
         setExtendedPublicKeyImporterFinalized(number, true);
       }
+    );
+    walletConfiguration.ledgerPolicyHmacs.forEach(
+      updateWalletPolicyRegistrations
     );
   };
 
@@ -601,6 +606,7 @@ CreateWallet.propTypes = {
   unknownSlices: PropTypes.arrayOf(PropTypes.shape(slicePropTypes)).isRequired,
   walletName: PropTypes.string.isRequired,
   walletDetailsText: PropTypes.string.isRequired,
+  updateWalletPolicyRegistrations: PropTypes.func.isRequired,
 };
 
 CreateWallet.defaultProps = {
@@ -648,6 +654,7 @@ const mapDispatchToProps = {
   setExtendedPublicKeyImporterVisible:
     setExtendedPublicKeyImporterVisibleAction,
   updateWalletNameAction: updateWalletNameActionImport,
+  updateWalletPolicyRegistrations: updateWalletPolicyRegistrationsAction,
   ...wrappedActions({
     setClientType: SET_CLIENT_TYPE,
     setClientUrl: SET_CLIENT_URL,

--- a/src/proptypes/wallet.js
+++ b/src/proptypes/wallet.js
@@ -1,0 +1,41 @@
+import PropTypes from "prop-types";
+
+// TODO: This should all be coming from typescript
+// types in unchained-wallets/bitcoin
+
+const ledgerPolicyHmacPropType = {
+  xfp: PropTypes.string.isRequired,
+  policyHmac: PropTypes.string.isRequired,
+};
+
+const extendedPublicKeyPropType = {
+  bip32Path: PropTypes.string.isRequired,
+  xfp: PropTypes.string.isRequired,
+  xpub: PropTypes.string.isRequired,
+};
+
+const quorumPropType = {
+  requiredSigners: PropTypes.number.isRequired,
+  totalSigners: PropTypes.number,
+};
+
+const walletConfigPropType = {
+  ledgerPolicyHmacs: PropTypes.arrayOf(
+    PropTypes.shape(ledgerPolicyHmacPropType)
+  ),
+  addressType: PropTypes.string.isRequired,
+  extendedPublicKeys: PropTypes.arrayOf(
+    PropTypes.shape(extendedPublicKeyPropType)
+  ),
+  name: PropTypes.string,
+  uuid: PropTypes.string,
+  network: PropTypes.string.isRequired,
+  quorum: PropTypes.shape(quorumPropType).isRequired,
+};
+
+export {
+  walletConfigPropType,
+  ledgerPolicyHmacPropType,
+  extendedPublicKeyPropType,
+  quorumPropType,
+};

--- a/src/reducers/walletReducer.js
+++ b/src/reducers/walletReducer.js
@@ -4,6 +4,7 @@ import {
   WALLET_MODES,
   UPDATE_WALLET_MODE,
   INITIAL_LOAD_COMPLETE,
+  UPDATE_POLICY_REGISTRATIONS,
 } from "../actions/walletActions";
 import updateState from "./utils";
 
@@ -11,6 +12,7 @@ const initialState = {
   walletMode: WALLET_MODES.VIEW,
   walletName: "My Multisig Wallet",
   nodesLoaded: false,
+  ledgerPolicyHmacs: [],
 };
 
 function resetWalletViews(state) {
@@ -27,6 +29,10 @@ export default (state = initialState, action) => {
       return updateState(state, { walletName: action.value });
     case RESET_WALLET_VIEW:
       return resetWalletViews(state);
+    case UPDATE_POLICY_REGISTRATIONS:
+      return updateState(state, {
+        ledgerPolicyHmacs: [...state.ledgerPolicyHmacs, action.value],
+      });
     case INITIAL_LOAD_COMPLETE:
       return updateState(state, { nodesLoaded: true });
     default:

--- a/src/selectors/wallet.js
+++ b/src/selectors/wallet.js
@@ -256,7 +256,12 @@ export const getWalletDetailsText = createSelector(
     ${extendedPublicKeys}
   ],
   "startingAddressIndex": ${startingAddressIndex},
-  "ledgerPolicyHmacs": [${ledgerPolicyHmacs}]
+  "ledgerPolicyHmacs": [${ledgerPolicyHmacs.map(JSON.stringify).join(", ")}]
 }`;
   }
+);
+
+export const getWalletConfig = createSelector(
+  [getWalletDetailsText],
+  JSON.parse
 );

--- a/src/selectors/wallet.js
+++ b/src/selectors/wallet.js
@@ -14,6 +14,8 @@ const getTotalSigners = (state) => state.settings.totalSigners;
 const getRequiredSigners = (state) => state.settings.requiredSigners;
 const getStartingAddressIndex = (state) => state.settings.startingAddressIndex;
 const getWalletName = (state) => state.wallet.common.walletName;
+const getWalletLedgerPolicyHmacs = (state) =>
+  state.wallet.common.ledgerPolicyHmacs;
 const getClientDetails = (state) => {
   if (state.client.type === "private") {
     return `{
@@ -228,6 +230,7 @@ export const getWalletDetailsText = createSelector(
     getTotalSigners,
     getExtendedPublicKeysBIP32Paths,
     getStartingAddressIndex,
+    getWalletLedgerPolicyHmacs,
   ],
   (
     walletName,
@@ -237,7 +240,8 @@ export const getWalletDetailsText = createSelector(
     requiredSigners,
     totalSigners,
     extendedPublicKeys,
-    startingAddressIndex
+    startingAddressIndex,
+    ledgerPolicyHmacs = []
   ) => {
     return `{
   "name": "${walletName}",
@@ -251,7 +255,8 @@ export const getWalletDetailsText = createSelector(
   "extendedPublicKeys": [
     ${extendedPublicKeys}
   ],
-  "startingAddressIndex": ${startingAddressIndex}
+  "startingAddressIndex": ${startingAddressIndex},
+  "ledgerPolicyHmacs": [${ledgerPolicyHmacs}]
 }`;
   }
 );

--- a/src/selectors/wallet.js
+++ b/src/selectors/wallet.js
@@ -14,6 +14,8 @@ const getTotalSigners = (state) => state.settings.totalSigners;
 const getRequiredSigners = (state) => state.settings.requiredSigners;
 const getStartingAddressIndex = (state) => state.settings.startingAddressIndex;
 const getWalletName = (state) => state.wallet.common.walletName;
+const getExtendedPublicKeyImporters = (state) =>
+  state.quorum.extendedPublicKeyImporters;
 const getWalletLedgerPolicyHmacs = (state) =>
   state.wallet.common.ledgerPolicyHmacs;
 const getClientDetails = (state) => {
@@ -264,4 +266,19 @@ export const getWalletDetailsText = createSelector(
 export const getWalletConfig = createSelector(
   [getWalletDetailsText],
   JSON.parse
+);
+
+export const getHmacsWithName = createSelector(
+  getExtendedPublicKeyImporters,
+  getWalletLedgerPolicyHmacs,
+  (extendedPublicKeys, policyHmacs) => {
+    return Object.values(extendedPublicKeys)
+      .map((importer) => {
+        const policyHmac = policyHmacs.find(
+          (hmac) => hmac.xfp === importer.rootXfp
+        )?.policyHmac;
+        return { policyHmac, name: importer.name };
+      })
+      .filter((registration) => registration.policyHmac);
+  }
 );

--- a/src/tests/addresses.jsx
+++ b/src/tests/addresses.jsx
@@ -63,7 +63,6 @@ class ConfirmMultisigAddressTest extends Test {
       network: this.params.network,
       bip32Path: this.params.bip32Path,
       multisig: this.params.multisig,
-      addressIndex: this.params.addressIndex,
       // only used with ledgers, version 2.1 and above
       policyHmac: this.params.policyHmac,
       ...braidDetailsToWalletConfig(
@@ -78,12 +77,9 @@ const addressTests = (keystore) =>
     // if ledger only return if policyHmac exists
     .filter((fixture) => (keystore === LEDGER ? fixture.policyHmac : true))
     .map((fixture) => {
-      // todo, this should be explicit, coming from the fixture
-      const addressIndex = fixture?.bip32Path.split("/").slice(-1)[0];
       return new ConfirmMultisigAddressTest({
         ...fixture,
         ...{ keystore },
-        addressIndex,
         expected: fixture.address,
       });
     });

--- a/src/tests/registration.jsx
+++ b/src/tests/registration.jsx
@@ -14,11 +14,6 @@ class RegisterWalletPolicyTest extends Test {
     return `Confirm ${this.params.network} ${this.params.type} multisig wallet policy`;
   }
 
-  // eslint-disable-next-line class-methods-use-this
-  postprocess(result) {
-    return result;
-  }
-
   expected() {
     return this.params.policyHmac;
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This starts to leverage new features introduced with Ledger's new bitcoin app that supports multisig wallet policy registration. Major features being introduced are explicit wallet registration, using a new serialization of ledger policy hmacs in the wallet config, and address verification. 

Requires an update to [unchained-wallets](https://github.com/unchained-capital/unchained-wallets/pull/99). This branch pinned to the working branch of uc-wallets and should be updated when that is published. 

New features:
- Main wallet entry page (where you confirm wallet details before viewing the wallet itself) has policy information and ability to register the wallet with device (coldcard and ledger supported)
- Can persist registration in local state to be downloaded via wallet config file
- Confirm Address on Ledger enabled. 
- Confirm address and signing will use registration if available from config
- Currently it does not save the registration if done as part of the address confirmation or signing

<!---
  Please describe your change(s) in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

## Does this PR introduce a breaking change?

<!--
  If this PR contains a breaking change,
  please also describe the impact and migration path for existing applications
-->

* [ ] Yes
* [x] No

## Does this PR fix an open issue?

<!-- If this PR contain fixes to open issues please link them here -->

* [ ] Yes
* [ ] No
