### PR TITLE
feat: add support for wallet uuid in configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ build/
 .DS_Store
 junit.xml
 .vscode
+.npmrc

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,8 +54,8 @@
         "redux-thunk": "^2.3.0",
         "reselect": "^4.0.0",
         "sass": "^1.56.2",
-        "unchained-bitcoin": "^0.3.1",
-        "unchained-wallets": "^0.4.0"
+        "unchained-bitcoin": "^0.4.1",
+        "unchained-wallets": "^0.5.1"
       },
       "devDependencies": {
         "@babel/plugin-transform-runtime": "^7.21.0",
@@ -11898,6 +11898,115 @@
         "language-subtag-registry": "~0.3.2"
       }
     },
+    "node_modules/ledger-bitcoin": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ledger-bitcoin/-/ledger-bitcoin-0.2.0.tgz",
+      "integrity": "sha512-EElKHrGMD8wcSLabULytrE5P+f+OKHVqEzmdfvtiRNH0j+3PYQqG7uPZnnSKzNt2egZwvMRzafRNLrl6MTlQcA==",
+      "dependencies": {
+        "@ledgerhq/hw-transport": "^6.20.0",
+        "bip32-path": "^0.4.2",
+        "bitcoinjs-lib": "^6.0.1",
+        "tiny-secp256k1": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/ledger-bitcoin/node_modules/@ledgerhq/devices": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-8.0.0.tgz",
+      "integrity": "sha512-gSnRT0KPca+LIpaC6D/WZQjOAlSI5uCvK1dmxXtKhODLAj735rX5Z3SnGnLUavRCHNbUi44FzgvloF5BKTkh7A==",
+      "dependencies": {
+        "@ledgerhq/errors": "^6.12.3",
+        "@ledgerhq/logs": "^6.10.1",
+        "rxjs": "6",
+        "semver": "^7.3.5"
+      }
+    },
+    "node_modules/ledger-bitcoin/node_modules/@ledgerhq/errors": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.12.3.tgz",
+      "integrity": "sha512-djiMSgB/7hnK3aLR/c5ZMMivxjcI7o2+y3VKcsZZpydPoVf9+FXqeJPRfOwmJ0JxbQ//LinUfWpIfHew8LkaVw=="
+    },
+    "node_modules/ledger-bitcoin/node_modules/@ledgerhq/hw-transport": {
+      "version": "6.28.1",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.28.1.tgz",
+      "integrity": "sha512-RaZe+abn0zBIz82cE9tp7Y7aZkHWWbEaE2yJpfxT8AhFz3fx+BU0kLYzuRN9fmA7vKueNJ1MTVUCY+Ex9/CHSQ==",
+      "dependencies": {
+        "@ledgerhq/devices": "^8.0.0",
+        "@ledgerhq/errors": "^6.12.3",
+        "events": "^3.3.0"
+      }
+    },
+    "node_modules/ledger-bitcoin/node_modules/@ledgerhq/logs": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-6.10.1.tgz",
+      "integrity": "sha512-z+ILK8Q3y+nfUl43ctCPuR4Y2bIxk/ooCQFwZxhtci1EhAtMDzMAx2W25qx8G1PPL9UUOdnUax19+F0OjXoj4w=="
+    },
+    "node_modules/ledger-bitcoin/node_modules/bech32": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
+    },
+    "node_modules/ledger-bitcoin/node_modules/bitcoinjs-lib": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-6.1.0.tgz",
+      "integrity": "sha512-eupi1FBTJmPuAZdChnzTXLv2HBqFW2AICpzXZQLniP0V9FWWeeUQSMKES6sP8isy/xO0ijDexbgkdEyFVrsuJw==",
+      "dependencies": {
+        "bech32": "^2.0.0",
+        "bip174": "^2.1.0",
+        "bs58check": "^2.1.2",
+        "create-hash": "^1.1.0",
+        "ripemd160": "^2.0.2",
+        "typeforce": "^1.11.3",
+        "varuint-bitcoin": "^1.1.2",
+        "wif": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/ledger-bitcoin/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ledger-bitcoin/node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ledger-bitcoin/node_modules/tiny-secp256k1": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-2.2.1.tgz",
+      "integrity": "sha512-/U4xfVqnVxJXN4YVsru0E6t5wVncu2uunB8+RVR40fYUxkKYUPS10f+ePQZgFBoE/Jbf9H1NBveupF2VmB58Ng==",
+      "dependencies": {
+        "uint8array-tools": "0.0.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ledger-bitcoin/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -15962,6 +16071,14 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/uint8array-tools": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/uint8array-tools/-/uint8array-tools-0.0.7.tgz",
+      "integrity": "sha512-vrrNZJiusLWoFWBqz5Y5KMCgP9W9hnjZHzZiZRT8oNAkq3d5Z5Oe76jAvVVSRh4U8GGR90N2X1dWtrhvx6L8UQ==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -15978,13 +16095,14 @@
       }
     },
     "node_modules/unchained-bitcoin": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/unchained-bitcoin/-/unchained-bitcoin-0.3.1.tgz",
-      "integrity": "sha512-avwHRj8EeTqczeESAogLmTdn3aukKwq+tIfU987H5ZC858xnF0MEolAkHuy0PKzfytS+LCJsUQj2sRL11pnr0A==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/unchained-bitcoin/-/unchained-bitcoin-0.4.1.tgz",
+      "integrity": "sha512-TwmPl4Ijd+05zLDiaKnxXLNfgtf1JL+dMst1UvFJ7ClXMmdenCkxvJJz9AyUtW2EYnsbjiWfNA4ywNhzp5aN8Q==",
       "dependencies": {
         "@babel/polyfill": "^7.7.0",
         "bignumber.js": "^8.1.1",
         "bip32": "^2.0.5",
+        "bip66": "^1.1.5",
         "bitcoin-address-validation": "^0.2.9",
         "bitcoinjs-lib": "^5.1.10",
         "bs58check": "^2.1.2",
@@ -16021,9 +16139,9 @@
       "hasInstallScript": true
     },
     "node_modules/unchained-wallets": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/unchained-wallets/-/unchained-wallets-0.4.0.tgz",
-      "integrity": "sha512-G04/12Ofx3TRFhlLwAh1HMNaQkhcJza5JTB18qFTYJtlnin1guFaZ3eM3z1v5AC8ZbiPvxbqo7ln5Cj3e1nLRg==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/unchained-wallets/-/unchained-wallets-0.5.1.tgz",
+      "integrity": "sha512-g2yWC7DaLvXTOQmCtErLXtB5+37ofaerOc3AHv5Ly2nEvBVKVxs0OkXm7N2Gns6WvkrhgkFI/Srdabfuylyd6g==",
       "dependencies": {
         "@babel/polyfill": "^7.7.0",
         "@ledgerhq/hw-app-btc": "^5.34.1",
@@ -16035,9 +16153,10 @@
         "bitcoinjs-lib": "^5.1.10",
         "bowser": "^2.6.1",
         "core-js": "^2.6.10",
+        "ledger-bitcoin": "^0.2.0",
         "punycode": "^2.1.1",
         "sha": "^3.0.0",
-        "unchained-bitcoin": "^0.3.1"
+        "unchained-bitcoin": "^0.4.1"
       },
       "engines": {
         "node": ">=16"
@@ -25628,6 +25747,99 @@
         "language-subtag-registry": "~0.3.2"
       }
     },
+    "ledger-bitcoin": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ledger-bitcoin/-/ledger-bitcoin-0.2.0.tgz",
+      "integrity": "sha512-EElKHrGMD8wcSLabULytrE5P+f+OKHVqEzmdfvtiRNH0j+3PYQqG7uPZnnSKzNt2egZwvMRzafRNLrl6MTlQcA==",
+      "requires": {
+        "@ledgerhq/hw-transport": "^6.20.0",
+        "bip32-path": "^0.4.2",
+        "bitcoinjs-lib": "^6.0.1",
+        "tiny-secp256k1": "^2.1.2"
+      },
+      "dependencies": {
+        "@ledgerhq/devices": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-8.0.0.tgz",
+          "integrity": "sha512-gSnRT0KPca+LIpaC6D/WZQjOAlSI5uCvK1dmxXtKhODLAj735rX5Z3SnGnLUavRCHNbUi44FzgvloF5BKTkh7A==",
+          "requires": {
+            "@ledgerhq/errors": "^6.12.3",
+            "@ledgerhq/logs": "^6.10.1",
+            "rxjs": "6",
+            "semver": "^7.3.5"
+          }
+        },
+        "@ledgerhq/errors": {
+          "version": "6.12.3",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.12.3.tgz",
+          "integrity": "sha512-djiMSgB/7hnK3aLR/c5ZMMivxjcI7o2+y3VKcsZZpydPoVf9+FXqeJPRfOwmJ0JxbQ//LinUfWpIfHew8LkaVw=="
+        },
+        "@ledgerhq/hw-transport": {
+          "version": "6.28.1",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.28.1.tgz",
+          "integrity": "sha512-RaZe+abn0zBIz82cE9tp7Y7aZkHWWbEaE2yJpfxT8AhFz3fx+BU0kLYzuRN9fmA7vKueNJ1MTVUCY+Ex9/CHSQ==",
+          "requires": {
+            "@ledgerhq/devices": "^8.0.0",
+            "@ledgerhq/errors": "^6.12.3",
+            "events": "^3.3.0"
+          }
+        },
+        "@ledgerhq/logs": {
+          "version": "6.10.1",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-6.10.1.tgz",
+          "integrity": "sha512-z+ILK8Q3y+nfUl43ctCPuR4Y2bIxk/ooCQFwZxhtci1EhAtMDzMAx2W25qx8G1PPL9UUOdnUax19+F0OjXoj4w=="
+        },
+        "bech32": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+          "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
+        },
+        "bitcoinjs-lib": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-6.1.0.tgz",
+          "integrity": "sha512-eupi1FBTJmPuAZdChnzTXLv2HBqFW2AICpzXZQLniP0V9FWWeeUQSMKES6sP8isy/xO0ijDexbgkdEyFVrsuJw==",
+          "requires": {
+            "bech32": "^2.0.0",
+            "bip174": "^2.1.0",
+            "bs58check": "^2.1.2",
+            "create-hash": "^1.1.0",
+            "ripemd160": "^2.0.2",
+            "typeforce": "^1.11.3",
+            "varuint-bitcoin": "^1.1.2",
+            "wif": "^2.0.1"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "tiny-secp256k1": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-2.2.1.tgz",
+          "integrity": "sha512-/U4xfVqnVxJXN4YVsru0E6t5wVncu2uunB8+RVR40fYUxkKYUPS10f+ePQZgFBoE/Jbf9H1NBveupF2VmB58Ng==",
+          "requires": {
+            "uint8array-tools": "0.0.7"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
     "leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -28762,6 +28974,11 @@
       "dev": true,
       "optional": true
     },
+    "uint8array-tools": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/uint8array-tools/-/uint8array-tools-0.0.7.tgz",
+      "integrity": "sha512-vrrNZJiusLWoFWBqz5Y5KMCgP9W9hnjZHzZiZRT8oNAkq3d5Z5Oe76jAvVVSRh4U8GGR90N2X1dWtrhvx6L8UQ=="
+    },
     "unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -28775,13 +28992,14 @@
       }
     },
     "unchained-bitcoin": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/unchained-bitcoin/-/unchained-bitcoin-0.3.1.tgz",
-      "integrity": "sha512-avwHRj8EeTqczeESAogLmTdn3aukKwq+tIfU987H5ZC858xnF0MEolAkHuy0PKzfytS+LCJsUQj2sRL11pnr0A==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/unchained-bitcoin/-/unchained-bitcoin-0.4.1.tgz",
+      "integrity": "sha512-TwmPl4Ijd+05zLDiaKnxXLNfgtf1JL+dMst1UvFJ7ClXMmdenCkxvJJz9AyUtW2EYnsbjiWfNA4ywNhzp5aN8Q==",
       "requires": {
         "@babel/polyfill": "^7.7.0",
         "bignumber.js": "^8.1.1",
         "bip32": "^2.0.5",
+        "bip66": "^1.1.5",
         "bitcoin-address-validation": "^0.2.9",
         "bitcoinjs-lib": "^5.1.10",
         "bs58check": "^2.1.2",
@@ -28812,9 +29030,9 @@
       }
     },
     "unchained-wallets": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/unchained-wallets/-/unchained-wallets-0.4.0.tgz",
-      "integrity": "sha512-G04/12Ofx3TRFhlLwAh1HMNaQkhcJza5JTB18qFTYJtlnin1guFaZ3eM3z1v5AC8ZbiPvxbqo7ln5Cj3e1nLRg==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/unchained-wallets/-/unchained-wallets-0.5.1.tgz",
+      "integrity": "sha512-g2yWC7DaLvXTOQmCtErLXtB5+37ofaerOc3AHv5Ly2nEvBVKVxs0OkXm7N2Gns6WvkrhgkFI/Srdabfuylyd6g==",
       "requires": {
         "@babel/polyfill": "^7.7.0",
         "@ledgerhq/hw-app-btc": "^5.34.1",
@@ -28826,9 +29044,10 @@
         "bitcoinjs-lib": "^5.1.10",
         "bowser": "^2.6.1",
         "core-js": "^2.6.10",
+        "ledger-bitcoin": "^0.2.0",
         "punycode": "^2.1.1",
         "sha": "^3.0.0",
-        "unchained-bitcoin": "^0.3.1"
+        "unchained-bitcoin": "^0.4.1"
       },
       "dependencies": {
         "bignumber.js": {

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "redux-thunk": "^2.3.0",
     "reselect": "^4.0.0",
     "sass": "^1.56.2",
-    "unchained-bitcoin": "^0.3.1",
-    "unchained-wallets": "^0.4.0"
+    "unchained-bitcoin": "^0.4.1",
+    "unchained-wallets": "^0.5.1"
   }
 }

--- a/src/actions/walletActions.js
+++ b/src/actions/walletActions.js
@@ -21,6 +21,7 @@ export const UPDATE_DEPOSIT_SLICE = "UPDATE_DEPOSIT_SLICE";
 export const UPDATE_CHANGE_SLICE = "UPDATE_CHANGE_SLICE";
 export const RESET_NODES_SPEND = "RESET_NODES_SPEND";
 export const UPDATE_WALLET_NAME = "UPDATE_WALLET_NAME";
+export const UPDATE_WALLET_UUID = "UPDATE_WALLET_UUID";
 export const UPDATE_WALLET_MODE = "UPDATE_WALLET_MODE";
 export const RESET_WALLET_VIEW = "RESET_WALLET_VIEW";
 export const RESET_WALLET = "RESET_WALLET";
@@ -302,6 +303,13 @@ export function setWalletModeAction(value) {
 export function updateWalletNameAction(number, value) {
   return {
     type: UPDATE_WALLET_NAME,
+    value,
+  };
+}
+
+export function updateWalletUuidAction(value) {
+  return {
+    type: UPDATE_WALLET_UUID,
     value,
   };
 }

--- a/src/components/Wallet/RegisterWallet.jsx
+++ b/src/components/Wallet/RegisterWallet.jsx
@@ -71,7 +71,12 @@ const WalletRegistrations = () => {
               <Box my={1}>
                 <Alert severity="info">
                   <AlertTitle>Wallet Policy Details</AlertTitle>
-                  Policy template: <code>{policy.template}</code>
+                  <p>
+                    Policy template: <code>{policy.template}</code>
+                  </p>
+                  <p>
+                    Wallet Uuid: <code>{policy.name}</code>
+                  </p>
                 </Alert>
               </Box>
             )}

--- a/src/components/Wallet/index.jsx
+++ b/src/components/Wallet/index.jsx
@@ -15,6 +15,7 @@ import {
   updateDepositSliceAction,
   updateWalletNameAction as updateWalletNameActionImport,
   updateWalletPolicyRegistrationsAction,
+  updateWalletUuidAction,
 } from "../../actions/walletActions";
 import { fetchSliceData as fetchSliceDataAction } from "../../actions/braidActions";
 import walletSelectors from "../../selectors";
@@ -260,6 +261,7 @@ class CreateWallet extends React.Component {
       setExtendedPublicKeyImporterFinalized,
       setExtendedPublicKeyImporterName,
       updateWalletNameAction,
+      updateWalletUuid,
       setClientType,
       setClientUrl,
       setClientUsername,
@@ -276,6 +278,8 @@ class CreateWallet extends React.Component {
       setNetwork(walletConfiguration.network);
     }
     updateWalletNameAction(0, walletConfiguration.name);
+    updateWalletUuid(walletConfiguration.uuid);
+
     // set client to unknown
     if (walletConfiguration.client) {
       setClientType(walletConfiguration.client.type);
@@ -607,6 +611,7 @@ CreateWallet.propTypes = {
   setClientUsername: PropTypes.func.isRequired,
   totalSigners: PropTypes.number.isRequired,
   updateWalletNameAction: PropTypes.func.isRequired,
+  updateWalletUuid: PropTypes.func.isRequired,
   unknownAddresses: PropTypes.arrayOf(PropTypes.string).isRequired,
   unknownSlices: PropTypes.arrayOf(PropTypes.shape(slicePropTypes)).isRequired,
   walletName: PropTypes.string.isRequired,
@@ -659,6 +664,7 @@ const mapDispatchToProps = {
   setExtendedPublicKeyImporterVisible:
     setExtendedPublicKeyImporterVisibleAction,
   updateWalletNameAction: updateWalletNameActionImport,
+  updateWalletUuid: updateWalletUuidAction,
   updateWalletPolicyRegistrations: updateWalletPolicyRegistrationsAction,
   ...wrappedActions({
     setClientType: SET_CLIENT_TYPE,

--- a/src/reducers/walletReducer.js
+++ b/src/reducers/walletReducer.js
@@ -1,5 +1,6 @@
 import {
   UPDATE_WALLET_NAME,
+  UPDATE_WALLET_UUID,
   RESET_WALLET_VIEW,
   WALLET_MODES,
   UPDATE_WALLET_MODE,
@@ -11,6 +12,7 @@ import updateState from "./utils";
 const initialState = {
   walletMode: WALLET_MODES.VIEW,
   walletName: "My Multisig Wallet",
+  walletUuid: "",
   nodesLoaded: false,
   ledgerPolicyHmacs: [],
 };
@@ -27,6 +29,8 @@ export default (state = initialState, action) => {
       return updateState(state, { walletMode: action.value });
     case UPDATE_WALLET_NAME:
       return updateState(state, { walletName: action.value });
+    case UPDATE_WALLET_UUID:
+      return updateState(state, { walletUuid: action.value });
     case RESET_WALLET_VIEW:
       return resetWalletViews(state);
     case UPDATE_POLICY_REGISTRATIONS:

--- a/src/selectors/wallet.js
+++ b/src/selectors/wallet.js
@@ -14,6 +14,7 @@ const getTotalSigners = (state) => state.settings.totalSigners;
 const getRequiredSigners = (state) => state.settings.requiredSigners;
 const getStartingAddressIndex = (state) => state.settings.startingAddressIndex;
 const getWalletName = (state) => state.wallet.common.walletName;
+const getWalletUuid = (state) => state.wallet.common.walletUuid;
 const getExtendedPublicKeyImporters = (state) =>
   state.quorum.extendedPublicKeyImporters;
 const getWalletLedgerPolicyHmacs = (state) =>
@@ -225,6 +226,7 @@ export const getDepositableSlices = createSelector(getDepositSlices, (slices) =>
 export const getWalletDetailsText = createSelector(
   [
     getWalletName,
+    getWalletUuid,
     getAddressType,
     getNetwork,
     getClientDetails,
@@ -236,6 +238,7 @@ export const getWalletDetailsText = createSelector(
   ],
   (
     walletName,
+    walletUuid,
     addressType,
     network,
     clientDetails,
@@ -247,6 +250,7 @@ export const getWalletDetailsText = createSelector(
   ) => {
     return `{
   "name": "${walletName}",
+  "uuid": "${walletUuid}",
   "addressType": "${addressType}",
   "network": "${network}",
   "client":  ${clientDetails},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Wallet configs needed explicit support for uuids now that there are wallet registrations. Names can be edited so there needs to be an identifier that can be assumed to not be editable. The config type does support an optional uuid. This makes sure to save this value in state and use it in the registration if possible. This will also need some dependency bumps to uc-bitcoin and uc-wallets that are forthcoming. The uc-wallets update will also make it so that the registration isn't malleable in another way- changing key order. 

deploying this to a test environment to try it. https://bucko13.github.io/caravan/#/help 

If you don't see the commit hash [2e7024b](https://github.com/unchained-capital/caravan/pull/297/commits/2e7024b241950a7ce2e9626712130d0f0f2ac8c5) in the bottom right, make sure to do a hard refresh.

<!---
  Please describe your change(s) in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

## Does this PR introduce a breaking change?

<!--
  If this PR contains a breaking change,
  please also describe the impact and migration path for existing applications
-->

* [x] Yes
* [ ] No

## Does this PR fix an open issue?

<!-- If this PR contain fixes to open issues please link them here -->

* [ ] Yes
* [x] No
