### PR TITLE
fix(scriptexplorer): Change the error message for spending from new wallet

### DIFF
--- a/src/components/ScriptExplorer/ScriptEntry.jsx
+++ b/src/components/ScriptExplorer/ScriptEntry.jsx
@@ -202,11 +202,7 @@ class ScriptEntry extends React.Component {
     } = this.props;
     const multisig = this.generateMultisig();
     const fetchUTXOsResult = await this.fetchUTXOs(multisig);
-    if (
-      fetchUTXOsResult &&
-      fetchUTXOsResult.utxos &&
-      fetchUTXOsResult.utxos.length
-    ) {
+    if (fetchUTXOsResult && fetchUTXOsResult.utxos) {
       const { utxos, balanceSats } = fetchUTXOsResult;
       let fetchUTXOsError = "";
       if (balanceSats.isLessThanOrEqualTo(0)) {

--- a/src/components/ScriptExplorer/ScriptEntry.jsx
+++ b/src/components/ScriptExplorer/ScriptEntry.jsx
@@ -228,7 +228,7 @@ class ScriptEntry extends React.Component {
     } else {
       this.setState({
         fetchedUTXOs: false,
-        fetchUTXOsError: "Failed to fetch UTXOs.",
+        fetchUTXOsError: "This address has a zero balance.",
       });
     }
   };

--- a/src/components/ScriptExplorer/ScriptEntry.jsx
+++ b/src/components/ScriptExplorer/ScriptEntry.jsx
@@ -202,7 +202,11 @@ class ScriptEntry extends React.Component {
     } = this.props;
     const multisig = this.generateMultisig();
     const fetchUTXOsResult = await this.fetchUTXOs(multisig);
-    if (fetchUTXOsResult) {
+    if (
+      fetchUTXOsResult &&
+      fetchUTXOsResult.utxos &&
+      fetchUTXOsResult.utxos.length
+    ) {
       const { utxos, balanceSats } = fetchUTXOsResult;
       let fetchUTXOsError = "";
       if (balanceSats.isLessThanOrEqualTo(0)) {
@@ -228,7 +232,7 @@ class ScriptEntry extends React.Component {
     } else {
       this.setState({
         fetchedUTXOs: false,
-        fetchUTXOsError: "This address has a zero balance.",
+        fetchUTXOsError: fetchUTXOsResult.fetchUTXOsError,
       });
     }
   };
@@ -241,10 +245,7 @@ class ScriptEntry extends React.Component {
       client
     );
 
-    if (addressData && addressData.utxos && addressData.utxos.length)
-      return addressData;
-
-    return false;
+    return addressData;
   };
 
   //


### PR DESCRIPTION
For a new wallet no UTXO's can be found. This results in an uninformative error message. The message is now changed to having 0 balance.

ISSUES: #172

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!---
  Please describe your change(s) in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

## Does this PR introduce a breaking change?

<!--
  If this PR contains a breaking change,
  please also describe the impact and migration path for existing applications
-->

* [ ] Yes
* [X] No

## Does this PR fix an open issue?

<!-- If this PR contain fixes to open issues please link them here -->

* [X] Yes
* [ ] No
