### PR TITLE
fix(sign): pass wallet uuid for signing

### DIFF
--- a/src/components/ScriptExplorer/SignatureImporter.jsx
+++ b/src/components/ScriptExplorer/SignatureImporter.jsx
@@ -142,6 +142,7 @@ class SignatureImporter extends React.Component {
       addressType,
       walletName,
       ledgerPolicyHmacs,
+      walletUuid,
     } = this.props;
     const { method } = signatureImporter;
 
@@ -168,6 +169,7 @@ class SignatureImporter extends React.Component {
             network,
             quorum: { requiredSigners },
             extendedPublicKeys,
+            uuid: walletUuid,
             name: walletName,
             ledgerPolicyHmacs,
           }}
@@ -583,6 +585,7 @@ SignatureImporter.propTypes = {
   unsignedTransaction: PropTypes.shape({}).isRequired,
   setSigningKey: PropTypes.func.isRequired,
   walletName: PropTypes.string.isRequired,
+  walletUuid: PropTypes.string.isRequired,
   // eslint-disable-next-line react/forbid-prop-types
   ledgerPolicyHmacs: PropTypes.array.isRequired,
 };
@@ -599,6 +602,7 @@ function mapStateToProps(state, ownProps) {
       fee: state.spend.transaction.fee,
       txid: state.spend.transaction.txid,
       walletName: state.wallet.common.walletName,
+      walletUuid: state.wallet.common.walletUuid,
     },
     ...state.spend.transaction,
     requiredSigners: state.settings.requiredSigners,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Turns out that the wallet uuid which is used now for ledger wallet registrations wasn't getting passed for signing and so the registration was failing validation.

I think this still needs to be fixed in the test suite though unfortunately and possibly at the fixture level (from unchained-bitcoin). But this gets signing working at least. 

<!---
  Please describe your change(s) in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

## Does this PR introduce a breaking change?

<!--
  If this PR contains a breaking change,
  please also describe the impact and migration path for existing applications
-->

* [ ] Yes
* [x] No

## Does this PR fix an open issue?

<!-- If this PR contain fixes to open issues please link them here -->

* [ ] Yes
* [x] No
