### PR TITLE
chore: s/blockstream.info/mempool.space/g

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ which can export these data can be made to work with Caravan.
 ### Consensus
 
 By default, Caravan uses a free API provided by
-[blockstream.info](https://blockstream.info) whenever it needs
+[mempool.space](https://mempool.space) whenever it needs
 information about the bitcoin blockchain or to broadcast transactions.
 
 You can ask Caravan to use your own private [bitcoind full

--- a/src/components/ClientPicker/index.jsx
+++ b/src/components/ClientPicker/index.jsx
@@ -139,7 +139,7 @@ const ClientPicker = ({
             {client.type === "public" && (
               <FormHelperText>
                 {"'Public' uses the "}
-                <code>blockstream.info</code>
+                <code>mempool.space</code>
                 {" API. Switch to private to use a "}
                 <code>bitcoind</code>
                 {" node."}

--- a/src/components/Help.tsx
+++ b/src/components/Help.tsx
@@ -155,7 +155,7 @@ const Help = () => (
               <p>
                 If you don&apos;t want to or cannot run your own full node,
                 Caravan defaults to using the freely available API at
-                <code> blockstream.info</code>.
+                <code> mempool.space</code>.
               </p>
             </CardContent>
           </Card>


### PR DESCRIPTION
## Description

Replace a couple of usages of blockstream.info with mempool.space.  Should be merged after https://github.com/unchained-capital/unchained-bitcoin/pull/99.

Also remove delay hack added in d9774c1c7e28021a48efa30666c6ceb9e75cd1da as it's not needed now that we're using mempool.space.

## Does this PR introduce a breaking change?

<!--
  If this PR contains a breaking change,
  please also describe the impact and migration path for existing applications
-->

* [ ] Yes
* [x] No

## Does this PR fix an open issue?

<!-- If this PR contain fixes to open issues please link them here -->

* [ ] Yes
* [x] No
