### PR TITLE
Unblock fee rate limit, add caption warning about mempool monitors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "redux-thunk": "^2.3.0",
         "reselect": "^4.0.0",
         "sass": "^1.56.2",
-        "unchained-bitcoin": "^1.0.1",
+        "unchained-bitcoin": "^1.2.0",
         "unchained-wallets": "^1.0.3"
       },
       "devDependencies": {
@@ -18943,9 +18943,9 @@
       }
     },
     "node_modules/unchained-bitcoin": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/unchained-bitcoin/-/unchained-bitcoin-1.0.2.tgz",
-      "integrity": "sha512-J8VJ1/zJZgikBNl/klbqFXqeIeQcYFlI+NlNRZ+lKZrIfvmZGHd2uZeuFjUj4jfPHsNhz9/xY1RRrxqKGZGY6w==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/unchained-bitcoin/-/unchained-bitcoin-1.2.0.tgz",
+      "integrity": "sha512-6zvPlZiJccAYZlTT8T/h+OkRykUTxzzTdDUId6z8qEbYuQR80CCoQIcUeed7A0ilPMp8EAmk0VV9K8qcMG4vRg==",
       "dependencies": {
         "@babel/polyfill": "^7.7.0",
         "bignumber.js": "^8.1.1",
@@ -33876,9 +33876,9 @@
       }
     },
     "unchained-bitcoin": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/unchained-bitcoin/-/unchained-bitcoin-1.0.2.tgz",
-      "integrity": "sha512-J8VJ1/zJZgikBNl/klbqFXqeIeQcYFlI+NlNRZ+lKZrIfvmZGHd2uZeuFjUj4jfPHsNhz9/xY1RRrxqKGZGY6w==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/unchained-bitcoin/-/unchained-bitcoin-1.2.0.tgz",
+      "integrity": "sha512-6zvPlZiJccAYZlTT8T/h+OkRykUTxzzTdDUId6z8qEbYuQR80CCoQIcUeed7A0ilPMp8EAmk0VV9K8qcMG4vRg==",
       "requires": {
         "@babel/polyfill": "^7.7.0",
         "bignumber.js": "^8.1.1",

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "redux-thunk": "^2.3.0",
     "reselect": "^4.0.0",
     "sass": "^1.56.2",
-    "unchained-bitcoin": "^1.0.1",
+    "unchained-bitcoin": "^1.2.0",
     "unchained-wallets": "^1.0.3"
   }
 }

--- a/src/components/ScriptExplorer/OutputsForm.jsx
+++ b/src/components/ScriptExplorer/OutputsForm.jsx
@@ -319,6 +319,10 @@ class OutputsForm extends React.Component {
                   }}
                 />
               </Box>
+              <Typography variant="caption" className={styles.outputsFormLabel}>
+                Refer to mempool monitoring websites to ensure your selected fee
+                rate is appropriate.
+              </Typography>
             </Grid>
 
             <Grid item xs={4}>

--- a/src/reducers/transactionReducer.js
+++ b/src/reducers/transactionReducer.js
@@ -163,8 +163,8 @@ function updateFeeRate(state, action) {
   // Get the fee. Ignore rate-too-high errors because this value creates
   // problems when trying to author a CPFP.
   const fee =
-    feeRateError === null &&
-    feeRateError !== FeeValidationError.FEE_RATE_TOO_HIGH
+    feeRateError === null ||
+    feeRateError === FeeValidationError.FEE_RATE_TOO_HIGH
       ? setFeeForRate(state, feeRateString, state.outputs.length)
       : "";
 


### PR DESCRIPTION
## Description

This updates unchained-bitcoin to v1.2.0

This change uses the new fee error types provided by unchained-bitcoin v1.2.0 to conditionally display fee error feedback. The conditional in this case is that `FeeValidationError.FEE_RATE_TOO_HIGH` is going to be ignored to allow for CPFP transactions to be authored in a high fee environment. A caption has been added to the fee rate input instructing the user to be responsible in researching fee rate acceptance on their own.

## Does this PR introduce a breaking change?

* [ ] Yes
* [x] No

## Does this PR fix an open issue?

Perhaps partially: https://github.com/unchained-capital/caravan/issues/169
