### PR TITLE
fix(build): pass git sha to build properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,8 +72,8 @@
     "vite-plugin-node-polyfills": "^0.7.0"
   },
   "scripts": {
-    "build": "npm run check && __GIT_SHA__=`git rev-parse --short HEAD` tsc && vite build",
-    "build:ci": "npm run ci && __GIT_SHA__=`git rev-parse --short HEAD` tsc && vite build",
+    "build": "npm run check && tsc && __GIT_SHA__=`git rev-parse --short HEAD` vite build",
+    "build:ci": "npm run ci && tsc && __GIT_SHA__=`git rev-parse --short HEAD` vite build",
     "check": "npm run lint && npm run test:ci",
     "ci": "npm run lint && npm run test:ci",
     "commit": "./node_modules/cz-customizable/standalone.js",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The commit hash wasn't getting built properly for prod builds. This updates the npm script to work the same as dev builds by making sure the string is in the right session. 

Before ([current deployment](https://unchained-capital.github.io/caravan/#/help)):
![Screenshot 2024-01-10 at 2 41 35 PM](https://github.com/unchained-capital/caravan/assets/4344978/3ae5949a-bc86-42db-ab1a-92990576876f)

Tested with a build [here](https://bucko13.github.io/caravan/#/help)
<!---
  Please describe your change(s) in detail.
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here.
-->

## Does this PR introduce a breaking change?

<!--
  If this PR contains a breaking change,
  please also describe the impact and migration path for existing applications
-->

* [ ] Yes
* [x] No

## Does this PR fix an open issue?

<!-- If this PR contain fixes to open issues please link them here -->

* [ ] Yes
* [x] No
