### PR TITLE
fix(dependencies): bump uc-wallets for trezor fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "reselect": "^4.0.0",
         "sass": "^1.56.2",
         "unchained-bitcoin": "^1.2.1",
-        "unchained-wallets": "^1.0.3"
+        "unchained-wallets": "^1.0.4"
       },
       "devDependencies": {
         "@babel/plugin-transform-runtime": "^7.21.0",
@@ -106,6 +106,57 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "../unchained-wallets": {
+      "version": "1.0.3",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/polyfill": "^7.7.0",
+        "@ledgerhq/hw-app-btc": "^5.34.1",
+        "@ledgerhq/hw-transport-u2f": "^5.34.0",
+        "@ledgerhq/hw-transport-webusb": "6.27.12",
+        "@trezor/connect-web": "9.0.11",
+        "bignumber.js": "^8.1.1",
+        "bitcoinjs-lib": "^5.1.10",
+        "bowser": "^2.6.1",
+        "core-js": "^2.6.10",
+        "ledger-bitcoin": "^0.2.0",
+        "punycode": "^2.1.1",
+        "sha": "^3.0.0",
+        "unchained-bitcoin": "^1.0.0"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.20.7",
+        "@babel/core": "^7.20.12",
+        "@babel/plugin-proposal-class-properties": "^7.18.6",
+        "@babel/preset-env": "^7.7.1",
+        "@babel/preset-typescript": "^7.18.6",
+        "@commitlint/cli": "^17.4.3",
+        "@commitlint/config-conventional": "^17.4.3",
+        "@types/jest": "^29.4.0",
+        "@types/node": "^18.13.0",
+        "@types/w3c-web-usb": "^1.0.6",
+        "@typescript-eslint/eslint-plugin": "^5.51.0",
+        "@typescript-eslint/parser": "^5.51.0",
+        "babel-plugin-transform-inline-environment-variables": "^0.4.3",
+        "eslint": "^8.34.0",
+        "eslint-plugin-import": "^2.27.5",
+        "eslint-plugin-jest": "^23.0.3",
+        "husky": "^8.0.3",
+        "jest": "^29.4.2",
+        "jest-environment-jsdom": "^29.4.1",
+        "jest-junit": "^9.0.0",
+        "jsdoc": "^4.0.0",
+        "lint-staged": "^13.1.2",
+        "mocha": "^10.2.0",
+        "prettier": "^2.8.4",
+        "ts-jest": "^29.0.5",
+        "typescript": "^4.9.5"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -4165,9 +4216,9 @@
       }
     },
     "node_modules/@ledgerhq/hw-transport-webusb/node_modules/@ledgerhq/errors": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.14.0.tgz",
-      "integrity": "sha512-ZWJw2Ti6Dq1Ott/+qYqJdDWeZm16qI3VNG5rFlb0TQ3UcAyLIQZbnnzzdcVVwVeZiEp66WIpINd/pBdqsHVyOA=="
+      "version": "6.16.1",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.16.1.tgz",
+      "integrity": "sha512-4D4wKecGzQpIu7sx03Sg4uE1e8g1oZUndWgw9gw776H8h9ov9c5TxPaldTn2j6orPECAERViLf7LTO4L5pE2Cw=="
     },
     "node_modules/@ledgerhq/hw-transport-webusb/node_modules/@ledgerhq/hw-transport": {
       "version": "6.28.1",
@@ -4180,9 +4231,9 @@
       }
     },
     "node_modules/@ledgerhq/hw-transport-webusb/node_modules/@ledgerhq/logs": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-6.10.1.tgz",
-      "integrity": "sha512-z+ILK8Q3y+nfUl43ctCPuR4Y2bIxk/ooCQFwZxhtci1EhAtMDzMAx2W25qx8G1PPL9UUOdnUax19+F0OjXoj4w=="
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-6.12.0.tgz",
+      "integrity": "sha512-ExDoj1QV5eC6TEbMdLUMMk9cfvNKhhv5gXol4SmULRVCx/3iyCPhJ74nsb3S0Vb+/f+XujBEj3vQn5+cwS0fNA=="
     },
     "node_modules/@ledgerhq/hw-transport-webusb/node_modules/lru-cache": {
       "version": "6.0.0",
@@ -4588,9 +4639,9 @@
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.3.tgz",
+      "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==",
       "engines": {
         "node": ">= 16"
       },
@@ -4783,9 +4834,9 @@
       }
     },
     "node_modules/@scure/base": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.3.tgz",
-      "integrity": "sha512-/+SgoRjLq7Xlf0CWuLHq2LUZeL/w65kfzAPG5NH9pcmBhs+nunQTn4gvdwgMTIXnt9b2C/1SeL2XiysZEyIC9Q==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.5.tgz",
+      "integrity": "sha512-Brj9FiG2W1MRQSTB212YVPRrcbjkv48FoZi/u4l/zds/ieRrqsh7aUf6CLwkAq61oKXr/ZlTzlY66gLIj3TFTQ==",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
@@ -5496,9 +5547,9 @@
       "dev": true
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.200",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.200.tgz",
-      "integrity": "sha512-YI/M/4HRImtNf3pJgbF+W6FrXovqj+T+/HpENLTooK9PnkacBsDpeP3IpHab40CClUfhNmdM2WTNP2sa2dni5Q=="
+      "version": "4.14.202",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
+      "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ=="
     },
     "node_modules/@types/long": {
       "version": "4.0.2",
@@ -14594,35 +14645,36 @@
       }
     },
     "node_modules/ledger-bitcoin/node_modules/@ledgerhq/devices": {
-      "version": "8.0.7",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-8.0.7.tgz",
-      "integrity": "sha512-BbPyET52lXnVs7CxJWrGYqmtGdbGzj+XnfCqLsDnA7QYr1CZREysxmie+Rr6BKpNDBRVesAovXjtaVaZOn+upw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-8.2.0.tgz",
+      "integrity": "sha512-XROTW2gTmmuy+YPPDjdtKKTQ3mfxrPtKtV+a9QFbj8f5MnjVMV0Zpy1BIB4CyIMsVVi4z6+nI67auT7IlsM3SQ==",
       "dependencies": {
-        "@ledgerhq/errors": "^6.14.0",
-        "@ledgerhq/logs": "^6.10.1",
-        "rxjs": "6",
+        "@ledgerhq/errors": "^6.16.1",
+        "@ledgerhq/logs": "^6.12.0",
+        "rxjs": "^7.8.1",
         "semver": "^7.3.5"
       }
     },
     "node_modules/ledger-bitcoin/node_modules/@ledgerhq/errors": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.14.0.tgz",
-      "integrity": "sha512-ZWJw2Ti6Dq1Ott/+qYqJdDWeZm16qI3VNG5rFlb0TQ3UcAyLIQZbnnzzdcVVwVeZiEp66WIpINd/pBdqsHVyOA=="
+      "version": "6.16.1",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.16.1.tgz",
+      "integrity": "sha512-4D4wKecGzQpIu7sx03Sg4uE1e8g1oZUndWgw9gw776H8h9ov9c5TxPaldTn2j6orPECAERViLf7LTO4L5pE2Cw=="
     },
     "node_modules/ledger-bitcoin/node_modules/@ledgerhq/hw-transport": {
-      "version": "6.28.8",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.28.8.tgz",
-      "integrity": "sha512-XxQVl4htd018u/M66r0iu5nlHi+J6QfdPsORzDF6N39jaz+tMqItb7tUlXM/isggcuS5lc7GJo7NOuJ8rvHZaQ==",
+      "version": "6.30.2",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.30.2.tgz",
+      "integrity": "sha512-iTB0cwQaISvUXwrnPOLAmPoAOMvW14XmtKsuQce0qYJZC/1/eUPNFu6sOD8X0qUBbMfWhre8X9AmMuWTPQH3lA==",
       "dependencies": {
-        "@ledgerhq/devices": "^8.0.7",
-        "@ledgerhq/errors": "^6.14.0",
+        "@ledgerhq/devices": "^8.2.0",
+        "@ledgerhq/errors": "^6.16.1",
+        "@ledgerhq/logs": "^6.12.0",
         "events": "^3.3.0"
       }
     },
     "node_modules/ledger-bitcoin/node_modules/@ledgerhq/logs": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-6.10.1.tgz",
-      "integrity": "sha512-z+ILK8Q3y+nfUl43ctCPuR4Y2bIxk/ooCQFwZxhtci1EhAtMDzMAx2W25qx8G1PPL9UUOdnUax19+F0OjXoj4w=="
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-6.12.0.tgz",
+      "integrity": "sha512-ExDoj1QV5eC6TEbMdLUMMk9cfvNKhhv5gXol4SmULRVCx/3iyCPhJ74nsb3S0Vb+/f+XujBEj3vQn5+cwS0fNA=="
     },
     "node_modules/ledger-bitcoin/node_modules/base-x": {
       "version": "4.0.0",
@@ -14678,6 +14730,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/ledger-bitcoin/node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/ledger-bitcoin/node_modules/semver": {
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
@@ -14691,6 +14751,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/ledger-bitcoin/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/ledger-bitcoin/node_modules/yallist": {
       "version": "4.0.0",
@@ -17244,9 +17309,9 @@
       }
     },
     "node_modules/ripple-binary-codec": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/ripple-binary-codec/-/ripple-binary-codec-1.10.0.tgz",
-      "integrity": "sha512-qWXxubgXBV3h5NTaaLiusZ1FhPqSy+bCYHHarfZ3bMmO2alRa1Ox61jvX1Zyozok8PcF3gs3bKwZci4RTlA07w==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/ripple-binary-codec/-/ripple-binary-codec-1.11.0.tgz",
+      "integrity": "sha512-g7+gs3T+NfoeW6vIq5dcN0CkIT4t/zwRzFxz8X2RzfbrWRnewPUKqQbmBgs05tXLX5NuWPaneiaAVpFpYBcdfw==",
       "dependencies": {
         "assert": "^2.0.0",
         "big-integer": "^1.6.48",
@@ -17260,9 +17325,9 @@
       }
     },
     "node_modules/ripple-binary-codec/node_modules/big-integer": {
-      "version": "1.6.51",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+      "version": "1.6.52",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
       "engines": {
         "node": ">=0.6"
       }
@@ -18992,9 +19057,9 @@
       "hasInstallScript": true
     },
     "node_modules/unchained-wallets": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/unchained-wallets/-/unchained-wallets-1.0.3.tgz",
-      "integrity": "sha512-LwI9pMNAW6KUjZShZgzmJWvnmCPoYTWw5gkDrZVA6dKwQvQbpu2EBXd3nQboIUPAcYk8x6DfaamHVsjJ5Bm/DA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unchained-wallets/-/unchained-wallets-1.0.4.tgz",
+      "integrity": "sha512-FRKksEC6IvX3J1Xans8h/cWZOdZqXEwlQdzd9P/tRo36cs9o7zyI2bbkL5/GKe5UGHohAr8K3w6craG/8Fq3yw==",
       "dependencies": {
         "@babel/polyfill": "^7.7.0",
         "@ledgerhq/hw-app-btc": "^5.34.1",
@@ -22687,9 +22752,9 @@
           }
         },
         "@ledgerhq/errors": {
-          "version": "6.14.0",
-          "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.14.0.tgz",
-          "integrity": "sha512-ZWJw2Ti6Dq1Ott/+qYqJdDWeZm16qI3VNG5rFlb0TQ3UcAyLIQZbnnzzdcVVwVeZiEp66WIpINd/pBdqsHVyOA=="
+          "version": "6.16.1",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.16.1.tgz",
+          "integrity": "sha512-4D4wKecGzQpIu7sx03Sg4uE1e8g1oZUndWgw9gw776H8h9ov9c5TxPaldTn2j6orPECAERViLf7LTO4L5pE2Cw=="
         },
         "@ledgerhq/hw-transport": {
           "version": "6.28.1",
@@ -22702,9 +22767,9 @@
           }
         },
         "@ledgerhq/logs": {
-          "version": "6.10.1",
-          "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-6.10.1.tgz",
-          "integrity": "sha512-z+ILK8Q3y+nfUl43ctCPuR4Y2bIxk/ooCQFwZxhtci1EhAtMDzMAx2W25qx8G1PPL9UUOdnUax19+F0OjXoj4w=="
+          "version": "6.12.0",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-6.12.0.tgz",
+          "integrity": "sha512-ExDoj1QV5eC6TEbMdLUMMk9cfvNKhhv5gXol4SmULRVCx/3iyCPhJ74nsb3S0Vb+/f+XujBEj3vQn5+cwS0fNA=="
         },
         "lru-cache": {
           "version": "6.0.0",
@@ -22898,9 +22963,9 @@
       }
     },
     "@noble/hashes": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.3.tgz",
+      "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA=="
     },
     "@noble/secp256k1": {
       "version": "1.7.1",
@@ -23040,9 +23105,9 @@
       }
     },
     "@scure/base": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.3.tgz",
-      "integrity": "sha512-/+SgoRjLq7Xlf0CWuLHq2LUZeL/w65kfzAPG5NH9pcmBhs+nunQTn4gvdwgMTIXnt9b2C/1SeL2XiysZEyIC9Q=="
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.5.tgz",
+      "integrity": "sha512-Brj9FiG2W1MRQSTB212YVPRrcbjkv48FoZi/u4l/zds/ieRrqsh7aUf6CLwkAq61oKXr/ZlTzlY66gLIj3TFTQ=="
     },
     "@sinclair/typebox": {
       "version": "0.27.8",
@@ -23670,9 +23735,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.200",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.200.tgz",
-      "integrity": "sha512-YI/M/4HRImtNf3pJgbF+W6FrXovqj+T+/HpENLTooK9PnkacBsDpeP3IpHab40CClUfhNmdM2WTNP2sa2dni5Q=="
+      "version": "4.14.202",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
+      "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ=="
     },
     "@types/long": {
       "version": "4.0.2",
@@ -30563,35 +30628,36 @@
       },
       "dependencies": {
         "@ledgerhq/devices": {
-          "version": "8.0.7",
-          "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-8.0.7.tgz",
-          "integrity": "sha512-BbPyET52lXnVs7CxJWrGYqmtGdbGzj+XnfCqLsDnA7QYr1CZREysxmie+Rr6BKpNDBRVesAovXjtaVaZOn+upw==",
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-8.2.0.tgz",
+          "integrity": "sha512-XROTW2gTmmuy+YPPDjdtKKTQ3mfxrPtKtV+a9QFbj8f5MnjVMV0Zpy1BIB4CyIMsVVi4z6+nI67auT7IlsM3SQ==",
           "requires": {
-            "@ledgerhq/errors": "^6.14.0",
-            "@ledgerhq/logs": "^6.10.1",
-            "rxjs": "6",
+            "@ledgerhq/errors": "^6.16.1",
+            "@ledgerhq/logs": "^6.12.0",
+            "rxjs": "^7.8.1",
             "semver": "^7.3.5"
           }
         },
         "@ledgerhq/errors": {
-          "version": "6.14.0",
-          "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.14.0.tgz",
-          "integrity": "sha512-ZWJw2Ti6Dq1Ott/+qYqJdDWeZm16qI3VNG5rFlb0TQ3UcAyLIQZbnnzzdcVVwVeZiEp66WIpINd/pBdqsHVyOA=="
+          "version": "6.16.1",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.16.1.tgz",
+          "integrity": "sha512-4D4wKecGzQpIu7sx03Sg4uE1e8g1oZUndWgw9gw776H8h9ov9c5TxPaldTn2j6orPECAERViLf7LTO4L5pE2Cw=="
         },
         "@ledgerhq/hw-transport": {
-          "version": "6.28.8",
-          "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.28.8.tgz",
-          "integrity": "sha512-XxQVl4htd018u/M66r0iu5nlHi+J6QfdPsORzDF6N39jaz+tMqItb7tUlXM/isggcuS5lc7GJo7NOuJ8rvHZaQ==",
+          "version": "6.30.2",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.30.2.tgz",
+          "integrity": "sha512-iTB0cwQaISvUXwrnPOLAmPoAOMvW14XmtKsuQce0qYJZC/1/eUPNFu6sOD8X0qUBbMfWhre8X9AmMuWTPQH3lA==",
           "requires": {
-            "@ledgerhq/devices": "^8.0.7",
-            "@ledgerhq/errors": "^6.14.0",
+            "@ledgerhq/devices": "^8.2.0",
+            "@ledgerhq/errors": "^6.16.1",
+            "@ledgerhq/logs": "^6.12.0",
             "events": "^3.3.0"
           }
         },
         "@ledgerhq/logs": {
-          "version": "6.10.1",
-          "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-6.10.1.tgz",
-          "integrity": "sha512-z+ILK8Q3y+nfUl43ctCPuR4Y2bIxk/ooCQFwZxhtci1EhAtMDzMAx2W25qx8G1PPL9UUOdnUax19+F0OjXoj4w=="
+          "version": "6.12.0",
+          "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-6.12.0.tgz",
+          "integrity": "sha512-ExDoj1QV5eC6TEbMdLUMMk9cfvNKhhv5gXol4SmULRVCx/3iyCPhJ74nsb3S0Vb+/f+XujBEj3vQn5+cwS0fNA=="
         },
         "base-x": {
           "version": "4.0.0",
@@ -30641,6 +30707,14 @@
             "yallist": "^4.0.0"
           }
         },
+        "rxjs": {
+          "version": "7.8.1",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+          "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
         "semver": {
           "version": "7.5.4",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
@@ -30648,6 +30722,11 @@
           "requires": {
             "lru-cache": "^6.0.0"
           }
+        },
+        "tslib": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+          "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "yallist": {
           "version": "4.0.0",
@@ -32594,9 +32673,9 @@
       }
     },
     "ripple-binary-codec": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/ripple-binary-codec/-/ripple-binary-codec-1.10.0.tgz",
-      "integrity": "sha512-qWXxubgXBV3h5NTaaLiusZ1FhPqSy+bCYHHarfZ3bMmO2alRa1Ox61jvX1Zyozok8PcF3gs3bKwZci4RTlA07w==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/ripple-binary-codec/-/ripple-binary-codec-1.11.0.tgz",
+      "integrity": "sha512-g7+gs3T+NfoeW6vIq5dcN0CkIT4t/zwRzFxz8X2RzfbrWRnewPUKqQbmBgs05tXLX5NuWPaneiaAVpFpYBcdfw==",
       "requires": {
         "assert": "^2.0.0",
         "big-integer": "^1.6.48",
@@ -32607,9 +32686,9 @@
       },
       "dependencies": {
         "big-integer": {
-          "version": "1.6.51",
-          "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-          "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg=="
+          "version": "1.6.52",
+          "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+          "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg=="
         }
       }
     },
@@ -33919,9 +33998,9 @@
       }
     },
     "unchained-wallets": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/unchained-wallets/-/unchained-wallets-1.0.3.tgz",
-      "integrity": "sha512-LwI9pMNAW6KUjZShZgzmJWvnmCPoYTWw5gkDrZVA6dKwQvQbpu2EBXd3nQboIUPAcYk8x6DfaamHVsjJ5Bm/DA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unchained-wallets/-/unchained-wallets-1.0.4.tgz",
+      "integrity": "sha512-FRKksEC6IvX3J1Xans8h/cWZOdZqXEwlQdzd9P/tRo36cs9o7zyI2bbkL5/GKe5UGHohAr8K3w6craG/8Fq3yw==",
       "requires": {
         "@babel/polyfill": "^7.7.0",
         "@ledgerhq/hw-app-btc": "^5.34.1",

--- a/package.json
+++ b/package.json
@@ -149,6 +149,6 @@
     "reselect": "^4.0.0",
     "sass": "^1.56.2",
     "unchained-bitcoin": "^1.2.1",
-    "unchained-wallets": "^1.0.3"
+    "unchained-wallets": "^1.0.4"
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes a bug with trezor address verification. A change to trezor connect broke the api. the fix in uc-wallets was to pin the connect iframe app it uses to interact with the device. 

Here's a successful address verification
![Screenshot 2024-01-29 at 9 14 58 AM](https://github.com/unchained-capital/caravan/assets/4344978/36cef90c-e477-4487-b95a-f0c92bdabf70)

## Does this PR introduce a breaking change?

<!--
  If this PR contains a breaking change,
  please also describe the impact and migration path for existing applications
-->

* [ ] Yes
* [x] No

## Does this PR fix an open issue?

<!-- If this PR contain fixes to open issues please link them here -->

* [ ] Yes
* [ ] No
